### PR TITLE
Fix NDEV-14877 allow customCA

### DIFF
--- a/charts/venafi-adapter/Chart.yaml
+++ b/charts/venafi-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: venafi-adapter
-version: v0.1.8
+version: v0.1.9
 appVersion: v0.1.0
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Nirmata Venafi Adapter

--- a/charts/venafi-adapter/Chart.yaml
+++ b/charts/venafi-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: venafi-adapter
-version: v0.1.7
+version: v0.1.8
 appVersion: v0.1.0
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Nirmata Venafi Adapter

--- a/charts/venafi-adapter/README.md
+++ b/charts/venafi-adapter/README.md
@@ -18,17 +18,17 @@ kubectl -n nirmata-venafi-adapter create configmap <e.g. ca-store-cm> —-from-f
 
 Create the namespace if needed with kubectl create namespace nirmata-venafi-adapter
 
-# 2. Install venafi-adapter from nirmata helm repo in the nirmata-kyverno-monitor namespace, with desired parameters.
+# 3. Install venafi-adapter from nirmata helm repo in the nirmata-kyverno-monitor namespace, with desired parameters.
 
 helm install venafi-adapter nirmata/venafi-adapter --namespace nirmata-venafi-adapter --create-namespace --set imagePullSecret.username=someuser,imagePullSecret.password=somepassword
 
 Other parameters corresponding to custom CA or HTTP proxies, NO_PROXY should be provided as needed. E.g.
 --set customCAConfigMap=<e.g. ca-store-cm> --set "extraEnvVars[0].name=HTTP_PROXY" --set "extraEnvVars[0].value=<e.g. http://test.com:8080>" ...
 
-# 3. Check pods are running
+# 4. Check pods are running
 kubectl -n <namespace> get pods 
 
-# 4. Check CRD is created (should show imagekey)
+# 5. Check CRD is created (should show imagekey)
 kubectl get crd
 ```
 
@@ -105,5 +105,5 @@ The following table lists the configurable parameters of the kyverno chart and t
 | venafiAdapterImage | string | `ghcr.io/nirmata/imagekey-controller` | Venafi adapter image |
 | venafiAdapterImageTag | string | `0.1.0` | Venafi adapter image tag. If empty, appVersion in Chart.yaml is used |
 | extraEnvVars | list | `[]` | Array of extra environment variables to pod as key: xxx, value: xxx pairs |
-| customCAConfigMap | string | | Config map storing custom CA certificate |
+| customCAConfigMap | string | | Configmap storing custom CA certificate |
 | systemCertPath | string | `/etc/ssl/certs` | Path containing ssl certs within the container. Used only if customCAConfigMap is used |

--- a/charts/venafi-adapter/README.md
+++ b/charts/venafi-adapter/README.md
@@ -13,9 +13,17 @@ This chart bootstraps a Venafi Adapter (a.k.a. ImageKey controller) on a [Kubern
 
 helm repo add nirmata https://nirmata.github.io/kyverno-charts/
 
+# 2. (Optional) If a custom CA is used, create a configmap corresponding to the same with key custom-ca.pem. E.g.
+kubectl -n nirmata-venafi-adapter create configmap <e.g. ca-store-cm> —-from-file=custom-ca.pem=<cert file e.g. some-cert.pem>
+
+Create the namespace if needed with kubectl create namespace nirmata-venafi-adapter
+
 # 2. Install venafi-adapter from nirmata helm repo in the nirmata-kyverno-monitor namespace, with desired parameters.
 
 helm install venafi-adapter nirmata/venafi-adapter --namespace nirmata-venafi-adapter --create-namespace --set imagePullSecret.username=someuser,imagePullSecret.password=somepassword
+
+Other parameters corresponding to custom CA or HTTP proxies, NO_PROXY should be provided as needed. E.g.
+--set customCAConfigMap=<e.g. ca-store-cm> --set "extraEnvVars[0].name=HTTP_PROXY" --set "extraEnvVars[0].value=<e.g. http://test.com:8080>" ...
 
 # 3. Check pods are running
 kubectl -n <namespace> get pods 
@@ -97,4 +105,5 @@ The following table lists the configurable parameters of the kyverno chart and t
 | venafiAdapterImage | string | `ghcr.io/nirmata/imagekey-controller` | Venafi adapter image |
 | venafiAdapterImageTag | string | `0.1.0` | Venafi adapter image tag. If empty, appVersion in Chart.yaml is used |
 | extraEnvVars | list | `[]` | Array of extra environment variables to pod as key: xxx, value: xxx pairs |
-
+| customCAConfigMap | string | | Config map storing custom CA certificate |
+| systemCertPath | string | `/etc/ssl/certs` | Path containing ssl certs within the container. Used only if customCAConfigMap is used |

--- a/charts/venafi-adapter/templates/deployment.yaml
+++ b/charts/venafi-adapter/templates/deployment.yaml
@@ -34,6 +34,13 @@ spec:
         - --logtostderr=true
         - --v=0
         image: ghcr.io/nirmata/kube-rbac-proxy:v0.13.1
+        {{- if .Values.customCAConfigMap }}
+        volumeMounts:
+        - name: custom-ca-store
+          mountPath: {{ .Values.systemCertPath }}/custom-ca.pem
+          subPath: custom-ca.pem
+          readOnly: false
+        {{- end}}
         livenessProbe:
           failureThreshold: 3
           initialDelaySeconds: 15
@@ -95,6 +102,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
+        - name: CUSTOM_CA_CONFMAP
+          value: {{ .Values.customCAConfigMap }}
+        - name: SYSTEM_CERT_PATH
+          value: {{ .Values.systemCertPath }}
         {{- range .Values.extraEnvVars }}
         - name: {{ .name }}
           value: {{ .value }}

--- a/charts/venafi-adapter/templates/deployment.yaml
+++ b/charts/venafi-adapter/templates/deployment.yaml
@@ -88,7 +88,6 @@ spec:
         - name: custom-ca-store
           mountPath: {{ .Values.systemCertPath }}/custom-ca.pem
           subPath: custom-ca.pem
-          readOnly: false
         {{- end}}
         livenessProbe:
           httpGet:

--- a/charts/venafi-adapter/templates/deployment.yaml
+++ b/charts/venafi-adapter/templates/deployment.yaml
@@ -76,6 +76,13 @@ spec:
         - /manager
         image: {{ .Values.venafiAdapterImage }}:{{ default .Chart.AppVersion .Values.venafiAdapterImageTag }}
         imagePullPolicy: Always
+        {{- if .Values.customCAConfigMap }}
+        volumeMounts:
+        - name: custom-ca-store
+          mountPath: {{ .Values.systemCertPath }}/custom-ca.pem
+          subPath: custom-ca.pem
+          readOnly: false
+        {{- end}}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -116,5 +123,11 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      {{- if .Values.customCAConfigMap }}
+      volumes:
+      - name: custom-ca-store
+        configMap:
+          name: {{ .Values.customCAConfigMap }}
+      {{- end}}
       serviceAccountName: imagekey-controller
       terminationGracePeriodSeconds: 10

--- a/charts/venafi-adapter/values.yaml
+++ b/charts/venafi-adapter/values.yaml
@@ -17,6 +17,12 @@ imagePullSecret:
   username:
   password:
 
+# -- Config map storing custom CA certificate
+customCAConfigMap:
+
+# -- Path containing ssl certs within the container. Used only if customCAConfigMap is used
+systemCertPath: /etc/ssl/certs
+
 # Used to pass environment variables to the deployment pod. E.g.
 # - name: HTTP_PROXY
 #   value: http://test.com:8080


### PR DESCRIPTION
Hi,

Supporting a custom CA for venafi adapter by allowing creation of a configmap with a constant key storing that CA and mounting it at a specific location in the pod.

Have not been able to test it though. 