### PR TITLE
[kube-bench-adapter] Avoid duplicate labels

### DIFF
--- a/charts/kube-bench-adapter/Chart.yaml
+++ b/charts/kube-bench-adapter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-bench-adapter
 description: The kube-bench adapter periodically runs a CIS benchmark check using cron-job with a tool called kube-bench and produces a cluster-wide policy report based on the Policy Report Custom Resource Definition
 type: application
-version: v1.2.2
+version: v1.2.3
 appVersion: "v0.2.1"
 maintainers:
   - name: Nirmata

--- a/charts/kube-bench-adapter/templates/_helpers.tpl
+++ b/charts/kube-bench-adapter/templates/_helpers.tpl
@@ -34,8 +34,6 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "kube-bench.labels" -}}
-app.kubernetes.io/instance: nirmata
-app.kubernetes.io/name: nirmata
 helm.sh/chart: {{ include "kube-bench.chart" . }}
 {{ include "kube-bench.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
@@ -43,12 +41,6 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
-
-{{/* matchLabels */}}
-{{- define "kube-bench.matchLabels" -}}
-app.kubernetes.io/name: nirmata
-app.kubernetes.io/instance: nirmata
-{{- end -}}
 
 {{/*
 Selector labels


### PR DESCRIPTION
This PR avoids the accidental creation of duplicate `app.kubernetes.io/instance` and `app.kubernetes.io/name` labels, which prevents deployment under fluxcd (*which doesn't simply tolerate duplicates like the helm cli does*)
