### PR TITLE
fix: oom killed error

### DIFF
--- a/charts/image-scan-adapter/Chart.yaml
+++ b/charts/image-scan-adapter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: image-scan-adapter
 description: A Helm chart for Kubernetes
 type: application
-version: "v0.1.5"
+version: "v0.1.6"
 appVersion: "v0.1.1"
 keywords:
   - kubernetes

--- a/charts/image-scan-adapter/templates/deployment.yaml
+++ b/charts/image-scan-adapter/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: {{ .Values.resourceMemoryLimit }}
           requests:
             cpu: 10m
             memory: 64Mi

--- a/charts/image-scan-adapter/values.yaml
+++ b/charts/image-scan-adapter/values.yaml
@@ -26,6 +26,9 @@ scanInterval: 12h
 # -- Disable selective scan, "false" by default
 scanAll: false
 
+# -- Memory limit for the resource, "128Mi" by default
+resourceMemoryLimit: 128Mi
+
 selectors:
   # -- Namespaces to run image scan on, by default adapter will scan all namespaces
   namespaces: []


### PR DESCRIPTION
Provide user with an option to set the resource memory limit in case of OOM killed due to not enough memory.

Quick fix for [NDEV-16129](https://nirmata.atlassian.net/browse/NDEV-16129).

[NDEV-16129]: https://nirmata.atlassian.net/browse/NDEV-16129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ