### PR TITLE
validate when kyverno upgraded from v1.9 to v1.10

### DIFF
--- a/charts/nirmata/templates/validate.yaml
+++ b/charts/nirmata/templates/validate.yaml
@@ -12,16 +12,16 @@
   {{- fail "Kyverno cannot be installed in namespace kube-system." -}}
 {{- end -}}
 
-{{- if not .Values.upgrade.fromV2 -}}
-  {{- $v2 := lookup "apps/v1" "Deployment" (include "kyverno.namespace" .) (include "kyverno.fullname" .) -}}
-  {{- if $v2 -}}
+{{- if not .Values.upgrade.fromV16 -}}
+  {{- $v16 := lookup "apps/v1" "Deployment" (include "kyverno.namespace" .) (include "kyverno.fullname" .) -}}
+  {{- if $v16 -}}
     {{- fail (join "\n" (list
       ""
       ""
       "  +--------------------------------------------------------------------------------------------------------------------------------------+"
       "  | An earlier Helm installation of Kyverno was detected.                                                                                |"
       "  | Given this chart version has significant breaking changes, the upgrade has been blocked.                                             |"
-      "  | Please review the release notes and chart README section and then, once prepared, set `upgrade.fromV2: true` once ready to proceed.  |"
+      "  | Please review the release notes and chart README section and then, once prepared, set `upgrade.fromV16: true` once ready to proceed. |"
       "  +--------------------------------------------------------------------------------------------------------------------------------------+"
       ""
       ))

--- a/charts/nirmata/values.yaml
+++ b/charts/nirmata/values.yaml
@@ -15,8 +15,8 @@ fullnameOverride: ~
 namespaceOverride: ~
 
 upgrade:
-  # -- Upgrading from v2 to v3 is not allowed by default, set this to true once changes have been reviewed.
-  fromV2: false
+  # -- Upgrading from v1.6 to v1.7 is not allowed by default, set this to true once changes have been reviewed.
+  fromV16: false
 
 apiVersionOverride:
   # -- (string) Override api version used to create `PodDisruptionBudget`` resources.


### PR DESCRIPTION
* When `Kyverno is upgraded from v1.9 to v1.10`, the nirmata `chart version is upgraded from v1.6 to v1.7`
* For caution, a validation step is added because `1.10` has many breaking changes. 