### PR TITLE
Add pss-baseline when pss-restricted is specified to profiles

### DIFF
--- a/charts/enterprise-kyverno-operator/Chart.yaml
+++ b/charts/enterprise-kyverno-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: enterprise-kyverno-operator
 description: Helm Chart for Enterprise Kyverno Operator
 type: application
-version: v0.2.13
+version: v0.2.14
 appVersion: v0.1.8
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png

--- a/charts/enterprise-kyverno-operator/templates/_helpers.tpl
+++ b/charts/enterprise-kyverno-operator/templates/_helpers.tpl
@@ -143,11 +143,11 @@ Create secret to access container registry
 
 {{- define "enterprise-kyverno.enabledPolicysets" -}}
 {{- if eq .Values.profile "dev" -}}
-    {{- default ("pod-security-baseline,rbac-best-practices") (join "," .Values.policies.policySets) -}}
+    {{- default ("pod-security-baseline") (join "," .Values.policies.policySets) -}}
 {{- else if eq .Values.profile "prod" -}}
-    {{- default ("pod-security-restricted,rbac-best-practices") (join "," .Values.policies.policySets) -}}
+    {{- default ("pod-security-restricted,pod-security-baseline,rbac-best-practices") (join "," .Values.policies.policySets) -}}
 {{- else -}}
-    {{- default ("pod-security-restricted") (join "," .Values.policies.policySets) -}}
+    {{- default ("pod-security-restricted, pod-security-baseline") (join "," .Values.policies.policySets) -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/enterprise-kyverno-operator/values.yaml
+++ b/charts/enterprise-kyverno-operator/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-profile: ""
+profile: "prod"
 
 namespace:
 


### PR DESCRIPTION
* When `pss-restricted` policyset is given, `pss-baseline` should also be included in profiles. 
* Changed the default profile to "prod"