### PR TITLE
fix NDEV-16559 and change pss restricted to include baseline

### DIFF
--- a/charts/enterprise-kyverno-operator/Chart.yaml
+++ b/charts/enterprise-kyverno-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: enterprise-kyverno-operator
 description: Helm Chart for Enterprise Kyverno Operator
 type: application
-version: v0.2.14
+version: v0.2.15
 appVersion: v0.1.8
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png

--- a/charts/enterprise-kyverno-operator/templates/cr-policysets.yaml
+++ b/charts/enterprise-kyverno-operator/templates/cr-policysets.yaml
@@ -1,4 +1,9 @@
-{{ range $pol := include "enterprise-kyverno.enabledPolicysets" . | split "," }}
+{{ $polstr := include "enterprise-kyverno.enabledPolicysets" . }}
+{{ if and (contains "pod-security-restricted" $polstr) (not (contains "pod-security-baseline" $polstr)) }}
+  {{ $polstr = printf "%s,%s" "pod-security-baseline" $polstr }}
+{{ end }}
+
+{{ range $pol := $polstr | split "," }}
 
 {{- $psetName := "invalid" -}}
 {{- $psetType := "" -}}
@@ -17,7 +22,7 @@
   {{- $psetType = "helm" -}}
   {{- $chartRepo = "https://nirmata.github.io/kyverno-policies" -}}
   {{- $chartName = "pss-baseline-policies" -}}
-  {{- $version = "0.2.1" -}}
+  {{- $version = "0.2.2" -}}
 {{- else if eq $pol "pod-security-restricted" -}}
   {{- $psetName = "pod-security-restricted" -}}
   {{- $psetType = "helm" -}}


### PR DESCRIPTION
Fixed the indentation error in a yaml of the kyverno-policies repo chart, updating that version here.
Also fixed NDEV-16551 regarding including pss-baseline if pss-restricted is provided.