### PR TITLE
fix: reduce places needing imagepullsecrets settings

### DIFF
--- a/charts/enterprise-kyverno-operator/Chart.yaml
+++ b/charts/enterprise-kyverno-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: enterprise-kyverno-operator
 description: Helm Chart for Enterprise Kyverno Operator
 type: application
 
-version: v0.2.21
+version: v0.2.22
 appVersion: v0.1.10
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png

--- a/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
+++ b/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
@@ -23,7 +23,7 @@ spec:
 
       {{- if eq .Values.cloudPlatform "aks" }}
       webhookAnnotations:
-        admissions.enforcer/disabled: true
+        'admissions.enforcer/disabled': true
       {{- end}}
 
       {{- if eq .Values.cloudPlatform "eks" }}

--- a/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
+++ b/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
@@ -38,16 +38,16 @@ spec:
           repository: {{ trimSuffix "kyverno" .Values.kyverno.image.repository  }}cleanup-controller
           tag: {{ .Values.kyverno.image.tag }}
           pullSecrets:
-          - name: imagepullsecret
+          - name: image-pull-secret
       image:
         pullSecrets:
-        - name: imagepullsecret
+        - name: image-pull-secret
       initImage:
         repository: {{ trimSuffix "kyverno" .Values.kyverno.image.repository  }}kyvernopre
         tag: {{ .Values.kyverno.image.tag }}
       {{- if .Values.image.pullSecrets.create }}
       imagePullSecrets:
-        imagepullsecret':
+        image-pull-secret:
           registry: {{.Values.image.pullSecrets.registry}}
           username: {{.Values.image.pullSecrets.username}}
           password: {{.Values.image.pullSecrets.password}}

--- a/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
+++ b/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
@@ -33,15 +33,34 @@ spec:
       {{- toYaml .Values.kyverno.helm | nindent 6 }}
       cleanupController:
         image:
-          repository: {{ .Values.kyverno.cleanupController.repository | default "ghcr.io/nirmata/cleanup-controller" }}
+          repository: {{ trimSuffix "kyverno" .Values.kyverno.image.repository  }}cleanup-controller
           tag: {{ .Values.kyverno.image.tag }}
+          pullSecrets:
+          - name: imagepullsecret
+      image:
+        pullSecrets:
+        - name: imagepullsecret
       initImage:
-        repository: {{ .Values.kyverno.initImage.repository  | default "ghcr.io/nirmata/kyvernopre" }}
+        repository: {{ trimSuffix "kyverno" .Values.kyverno.image.repository  }}kyvernopre
         tag: {{ .Values.kyverno.image.tag }}
+      {{- if .Values.image.pullSecrets.create }}
+      imagePullSecrets:
+        imagepullsecret':
+          registry: {{.Values.image.pullSecrets.registry}}
+          username: {{.Values.image.pullSecrets.username}}
+          password: {{.Values.image.pullSecrets.password}}
+      {{- end}}
       {{- if and (eq .Values.kyverno.enablePolicyExceptions true) (contains "v1.9" .Values.kyverno.image.tag) }}
       extraArgs:
       - --enablePolicyException=true
       - --loggingFormat=text
       - --exceptionNamespace={{ include "kyverno.namespace" . }}
       {{- end }}
+      rbac:
+        serviceAccount:
+          name: kyverno
+      licenseManager:
+        imageRepository: {{ trimSuffix "kyverno" .Values.kyverno.image.repository  }}kyverno-license-manager
+        imageTag: "v0.1.1"
+        productName: ""
 {{- end }}

--- a/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
+++ b/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
@@ -30,7 +30,9 @@ spec:
       hostNetwork: true
       {{- end }}
 
+      {{- if .Values.kyverno.helm }}
       {{- toYaml .Values.kyverno.helm | nindent 6 }}
+      {{- end}}
       cleanupController:
         image:
           repository: {{ trimSuffix "kyverno" .Values.kyverno.image.repository  }}cleanup-controller

--- a/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
+++ b/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
@@ -23,7 +23,7 @@ spec:
 
       {{- if eq .Values.cloudPlatform "aks" }}
       webhookAnnotations:
-        'admissions.enforcer/disabled': true
+        'admissions.enforcer/disabled': 'true'
       {{- end}}
 
       {{- if eq .Values.cloudPlatform "eks" }}
@@ -36,16 +36,16 @@ spec:
           repository: {{ trimSuffix "kyverno" .Values.kyverno.image.repository  }}cleanup-controller
           tag: {{ .Values.kyverno.image.tag }}
           pullSecrets:
-          - name: image-pull-secret
+          - name: imagepullsecret
       image:
         pullSecrets:
-        - name: image-pull-secret
+        - name: imagepullsecret
       initImage:
         repository: {{ trimSuffix "kyverno" .Values.kyverno.image.repository  }}kyvernopre
         tag: {{ .Values.kyverno.image.tag }}
       {{- if .Values.image.pullSecrets.create }}
       imagePullSecrets:
-        'image-pull-secret':
+        imagepullsecret':
           registry: {{.Values.image.pullSecrets.registry}}
           username: {{.Values.image.pullSecrets.username}}
           password: {{.Values.image.pullSecrets.password}}

--- a/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
+++ b/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
@@ -33,34 +33,15 @@ spec:
       {{- toYaml .Values.kyverno.helm | nindent 6 }}
       cleanupController:
         image:
-          repository: {{ trimSuffix "kyverno" .Values.kyverno.image.repository  }}cleanup-controller
+          repository: {{ .Values.kyverno.cleanupController.repository | default "ghcr.io/nirmata/cleanup-controller" }}
           tag: {{ .Values.kyverno.image.tag }}
-          pullSecrets:
-          - name: imagepullsecret
-      image:
-        pullSecrets:
-        - name: imagepullsecret
       initImage:
-        repository: {{ trimSuffix "kyverno" .Values.kyverno.image.repository  }}kyvernopre
+        repository: {{ .Values.kyverno.initImage.repository  | default "ghcr.io/nirmata/kyvernopre" }}
         tag: {{ .Values.kyverno.image.tag }}
-      {{- if .Values.image.pullSecrets.create }}
-      imagePullSecrets:
-        imagepullsecret':
-          registry: {{.Values.image.pullSecrets.registry}}
-          username: {{.Values.image.pullSecrets.username}}
-          password: {{.Values.image.pullSecrets.password}}
-      {{- end}}
       {{- if and (eq .Values.kyverno.enablePolicyExceptions true) (contains "v1.9" .Values.kyverno.image.tag) }}
       extraArgs:
       - --enablePolicyException=true
       - --loggingFormat=text
       - --exceptionNamespace={{ include "kyverno.namespace" . }}
       {{- end }}
-      rbac:
-        serviceAccount:
-          name: kyverno
-      licenseManager:
-        imageRepository: {{ trimSuffix "kyverno" .Values.kyverno.image.repository  }}kyverno-license-manager
-        imageTag: "v0.1.1"
-        productName: ""
 {{- end }}

--- a/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
+++ b/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
@@ -23,7 +23,7 @@ spec:
 
       {{- if eq .Values.cloudPlatform "aks" }}
       webhookAnnotations:
-        'admissions.enforcer/disabled': 'true'
+        admissions.enforcer/disabled: true
       {{- end}}
 
       {{- if eq .Values.cloudPlatform "eks" }}
@@ -45,7 +45,7 @@ spec:
         tag: {{ .Values.kyverno.image.tag }}
       {{- if .Values.image.pullSecrets.create }}
       imagePullSecrets:
-        image-pull-secret:
+        'image-pull-secret':
           registry: {{.Values.image.pullSecrets.registry}}
           username: {{.Values.image.pullSecrets.username}}
           password: {{.Values.image.pullSecrets.password}}

--- a/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
+++ b/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
@@ -33,15 +33,34 @@ spec:
       {{- toYaml .Values.kyverno.helm | nindent 6 }}
       cleanupController:
         image:
-          repository: {{ .Values.kyverno.cleanupController.repository | default "ghcr.io/nirmata/cleanup-controller" }}
+          repository: {{ trimSuffix "kyverno" .Values.kyverno.image.repository  }}cleanup-controller
           tag: {{ .Values.kyverno.image.tag }}
+          pullSecrets:
+          - name: image-pull-secret
+      image:
+        pullSecrets:
+        - name: image-pull-secret
       initImage:
-        repository: {{ .Values.kyverno.initImage.repository  | default "ghcr.io/nirmata/kyvernopre" }}
+        repository: {{ trimSuffix "kyverno" .Values.kyverno.image.repository  }}kyvernopre
         tag: {{ .Values.kyverno.image.tag }}
+      {{- if .Values.image.pullSecrets.create }}
+      imagePullSecrets:
+        image-pull-secret:
+          registry: {{.Values.image.pullSecrets.registry}}
+          username: {{.Values.image.pullSecrets.username}}
+          password: {{.Values.image.pullSecrets.password}}
+      {{- end}}
       {{- if and (eq .Values.kyverno.enablePolicyExceptions true) (contains "v1.9" .Values.kyverno.image.tag) }}
       extraArgs:
       - --enablePolicyException=true
       - --loggingFormat=text
       - --exceptionNamespace={{ include "kyverno.namespace" . }}
       {{- end }}
+      rbac:
+        serviceAccount:
+          name: kyverno
+      licenseManager:
+        imageRepository: {{ trimSuffix "kyverno" .Values.kyverno.image.repository  }}kyverno-license-manager
+        imageTag: "v0.1.1"
+        productName: ""
 {{- end }}

--- a/charts/enterprise-kyverno-operator/templates/pre-delete-hook.yaml
+++ b/charts/enterprise-kyverno-operator/templates/pre-delete-hook.yaml
@@ -18,6 +18,8 @@ spec:
         app: {{ template "enterprise-kyverno.name" . }}-operator
 {{ include "enterprise-kyverno.labels" . | indent 8 }}
     spec:
+      imagePullSecrets: 
+      - name: {{ .Values.image.pullSecrets.name }}
       serviceAccountName: {{ template "enterprise-kyverno.rbac.serviceAccountName" . }}
       securityContext:
         runAsUser: 1000

--- a/charts/enterprise-kyverno-operator/values.yaml
+++ b/charts/enterprise-kyverno-operator/values.yaml
@@ -59,8 +59,6 @@ kyverno:
     enable: false
   crds:
     annotations: []
-  initImage:
-    repository:
   cleanupController:
     # -- Enable cleanup controller.
     enabled: true
@@ -85,14 +83,8 @@ kyverno:
     # -- Image tag
     tag: v1.9.5-n4k.nirmata.1
 
-  # Additional parameters for Kyverno from Kyverno Helm Chart
+  # Kyverno Helm Chart customizations other than those already in kyverno CR
   helm:
-    rbac:
-      serviceAccount:
-        name: kyverno
-    licenseManager:
-      imageTag: "v0.1.1"
-      productName: ""
 
 policies:
   policySets:
@@ -196,7 +188,7 @@ ingress:
 
 resources:
   limits:
-    memory: 128Mi
+    memory: 256Mi
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
- Consolidated default registry settings needed to specify in values.yeml for private registries with pullsecrets. 
- Increased pod memory limit to 256Mb