### PR TITLE
NDEV-16721, NDEV-16722 exclude Namespaces from Kyverno Webhook. 

### DIFF
--- a/charts/enterprise-kyverno-operator/Chart.yaml
+++ b/charts/enterprise-kyverno-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: enterprise-kyverno-operator
 description: Helm Chart for Enterprise Kyverno Operator
 type: application
 
-version: v0.2.23
+version: v0.2.26
 appVersion: v0.1.10
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png

--- a/charts/enterprise-kyverno-operator/templates/_helpers.tpl
+++ b/charts/enterprise-kyverno-operator/templates/_helpers.tpl
@@ -154,3 +154,12 @@ Create secret to access container registry
 {{- define "enterprise-kyverno.policysetsStr" -}}
 {{- range (include "enterprise-kyverno.enabledPolicysets" . | split ",") }}{{(print . " ") }} {{- end }}
 {{- end -}}
+
+{{- define "kyverno.excludedNamespaces" -}}
+{{- $defaultNamespaces := list "kube-system" "nirmata" "nirmata-system" -}}
+{{- if eq .Values.cloudPlatform "openshift" -}}
+{{- $defaultNamespaces = append $defaultNamespaces "openshift-*" }}
+{{- end -}}
+{{- $excludedNamespaces := concat $defaultNamespaces .Values.kyverno.excludedNamespaces -}}
+{{ toJson $excludedNamespaces }}
+{{- end }}

--- a/charts/enterprise-kyverno-operator/templates/_helpers.tpl
+++ b/charts/enterprise-kyverno-operator/templates/_helpers.tpl
@@ -160,6 +160,6 @@ Create secret to access container registry
 {{- if eq .Values.cloudPlatform "openshift" -}}
 {{- $defaultNamespaces = append $defaultNamespaces "openshift-*" }}
 {{- end -}}
-{{- $excludedNamespaces := concat $defaultNamespaces .Values.kyverno.excludedNamespaces -}}
+{{- $excludedNamespaces := concat $defaultNamespaces .Values.kyverno.excludedNamespacesForWebhook -}}
 {{ toJson $excludedNamespaces }}
 {{- end }}

--- a/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
+++ b/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
@@ -17,6 +17,19 @@ spec:
 
   helm:
     values:
+      config:
+        webhooks:
+        #Exclude namespaces
+        - namespaceSelector:
+            matchExpressions:
+            - key: kubernetes.io/metadata.name
+              operator: NotIn
+              values:
+              {{- $excludedNamespaces := include "kyverno.excludedNamespaces" . | fromJsonArray }}
+              {{- range $excludedNamespaces}}
+              - {{.}}
+              {{- end }}
+        
       {{- if eq .Values.cloudPlatform "openshift" }}
       securityContext: null
       {{- end}}

--- a/charts/enterprise-kyverno-operator/values.yaml
+++ b/charts/enterprise-kyverno-operator/values.yaml
@@ -82,6 +82,8 @@ kyverno:
     repository: ghcr.io/nirmata/kyverno
     # -- Image tag
     tag: v1.9.5-n4k.nirmata.1
+  
+  excludedNamespaces: []
 
   # Kyverno Helm Chart customizations other than those already in kyverno CR
   helm:

--- a/charts/enterprise-kyverno-operator/values.yaml
+++ b/charts/enterprise-kyverno-operator/values.yaml
@@ -83,7 +83,7 @@ kyverno:
     # -- Image tag
     tag: v1.9.5-n4k.nirmata.1
   
-  excludedNamespaces: []
+  excludedNamespacesForWebhook: []
 
   # Kyverno Helm Chart customizations other than those already in kyverno CR
   helm:

--- a/charts/enterprise-kyverno-operator/values.yaml
+++ b/charts/enterprise-kyverno-operator/values.yaml
@@ -82,7 +82,7 @@ kyverno:
     repository: ghcr.io/nirmata/kyverno
     # -- Image tag
     tag: v1.9.5-n4k.nirmata.1
-  
+
   excludedNamespacesForWebhook: []
 
   # Kyverno Helm Chart customizations other than those already in kyverno CR


### PR DESCRIPTION
# NDEV-16721
* By default, `kyverno`, `kube-system`, `nirmata` & `nirmata-system` are excluded. 

# NDEV-16722
* if `.Values.cloudPlatform` is set to `openshift` then namespaces matching `openshift-*` will be excluded.

### If there is a need to exclude custom namespaces, user can do it by providing required namespaces to `.Values.kyverno.excludedNamespacesForWebhook`. 