### PR TITLE
Hyperkube to kubectl

### DIFF
--- a/charts/enterprise-kyverno-operator/Chart.yaml
+++ b/charts/enterprise-kyverno-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: enterprise-kyverno-operator
 description: Helm Chart for Enterprise Kyverno Operator
 type: application
 
-version: v0.2.26
+version: v0.2.27
 appVersion: v0.1.12
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png

--- a/charts/enterprise-kyverno-operator/templates/pre-delete-hook.yaml
+++ b/charts/enterprise-kyverno-operator/templates/pre-delete-hook.yaml
@@ -27,7 +27,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: kubectl
-          image: {{ .Values.predeletehookimage | default "k8s.gcr.io/hyperkube:v1.16.12" }}
+          image: {{ .Values.predeletehookimage | default "ghcr.io/nirmata/kubectl:1.24" }}
           imagePullPolicy: IfNotPresent
           command:
           - /bin/sh


### PR DESCRIPTION
We only need kubectl for pre delete hook. Hypercube bundles a lot more. Not needed.