### PR TITLE
fix boolean value handling in preventPolicyTamper

### DIFF
--- a/charts/enterprise-kyverno-operator/Chart.yaml
+++ b/charts/enterprise-kyverno-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: enterprise-kyverno-operator
 description: Helm Chart for Enterprise Kyverno Operator
 type: application
 
-version: v0.2.28
+version: v0.2.29
 appVersion: v0.1.12
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png

--- a/charts/enterprise-kyverno-operator/templates/_helpers.tpl
+++ b/charts/enterprise-kyverno-operator/templates/_helpers.tpl
@@ -132,13 +132,22 @@ Create secret to access container registry
 {{- end -}}
 
 {{- define "enterprise-kyverno.preventPolicyTamper" -}}
-{{- if eq .Values.profile "dev" -}}
-    {{- default false .Values.preventPolicyTamper -}}
-{{- else if eq .Values.profile "prod" -}}
-    {{- default true .Values.preventPolicyTamper -}}
-{{- else -}}
-    {{- default true .Values.preventPolicyTamper -}}
-{{- end -}}
+{{- $polTamperStr := lower (toString .Values.preventPolicyTamper) }}
+
+{{- if eq $polTamperStr "false" }}
+    {{- false }}
+{{- else if eq $polTamperStr "true"}}
+    {{- true }}
+{{- else }}
+    {{- if eq .Values.profile "dev" -}}
+        {{- false }}
+    {{- else if eq .Values.profile "prod" -}}
+        {{- true }}
+    {{- else -}}
+        {{- true }}
+    {{- end -}}
+{{- end}}
+
 {{- end -}}
 
 {{- define "enterprise-kyverno.enabledPolicysets" -}}

--- a/charts/enterprise-kyverno-operator/templates/cr-policysets.yaml
+++ b/charts/enterprise-kyverno-operator/templates/cr-policysets.yaml
@@ -18,31 +18,31 @@
   {{- $psetType = "helm" -}}
   {{- $chartRepo = "https://nirmata.github.io/kyverno-policies" -}}
   {{- $chartName = "kubernetes-best-practice-policies" -}}
-  {{- $version = "0.1.2" -}}
+  {{- $version = "0.2.1" -}}
 {{- else if eq $pol "pod-security-baseline" -}}
   {{- $psetName = "pod-security-baseline" -}}
   {{- $psetType = "helm" -}}
   {{- $chartRepo = "https://nirmata.github.io/kyverno-policies" -}}
   {{- $chartName = "pss-baseline-policies" -}}
-  {{- $version = "0.2.3" -}}
+  {{- $version = "0.2.4" -}}
 {{- else if eq $pol "pod-security-restricted" -}}
   {{- $psetName = "pod-security-restricted" -}}
   {{- $psetType = "helm" -}}
   {{- $chartRepo = "https://nirmata.github.io/kyverno-policies" -}}
   {{- $chartName = "pss-restricted-policies" -}}
-  {{- $version = "0.2.3" -}}
+  {{- $version = "0.2.4" -}}
 {{- else if eq $pol "rbac-best-practices" -}}
   {{- $psetName = "rbac-best-practices" -}}
   {{- $psetType = "helm" -}}
   {{- $chartRepo = "https://nirmata.github.io/kyverno-policies" -}}
   {{- $chartName = "rbac-best-practice-policies" -}}
-  {{- $version = "0.1.1" -}}
+  {{- $version = "0.1.2" -}}
 {{- else if eq $pol "multitenancy-best-practices" -}}
   {{- $psetName = "multitenancy-best-practices" -}}
   {{- $psetType = "helm" -}}
   {{- $chartRepo = "https://nirmata.github.io/kyverno-policies" -}}
   {{- $chartName = "multitenancy-best-practice-policies" -}}
-  {{- $version = "0.1.1" -}}
+  {{- $version = "0.1.2" -}}
 {{- end -}}
 
 {{- if ne $psetName "invalid" -}}


### PR DESCRIPTION
Empty and "false" check for boolean parameters in helm charts are considered equivalent. That led to an issue in setting the default value of the preventPolicyTamper flag.

Also updated to latest helm chart for kyverno-policies