### PR TITLE
NDEV-17006 support null values in kyverno CR helm section

### DIFF
--- a/charts/enterprise-kyverno-operator/Chart.yaml
+++ b/charts/enterprise-kyverno-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: enterprise-kyverno-operator
 description: Helm Chart for Enterprise Kyverno Operator
 type: application
 
-version: v0.2.33
-appVersion: v0.1.14
+version: v0.2.34
+appVersion: v0.1.15
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 keywords:

--- a/charts/enterprise-kyverno-operator/README.md
+++ b/charts/enterprise-kyverno-operator/README.md
@@ -113,7 +113,7 @@ There are platform specific configurations in which the Kyverno Helm chart confi
 | kyverno.image.tag | string | `v1.9.5-n4k.nirmata.1` | Image tag (defaults to chart app version) |
 | kyverno.enablePolicyExceptions| bool | `true` | Enable policyexceptions feature in Kyverno 1.9+ |
 | kyverno.excludedNamespacesForWebhook | list | `{kyverno, kube-system, nirmata, nirmata-system}` | Namespaces to exclude from Kyverno webhook |
-| kyverno.helm | object | `helm.rbac.serviceAccount.name=kyverno` | Free form yaml section with helm parameters in Kyverno chart. See all parameters [here](https://github.com/nirmata/kyverno-charts/tree/main/charts/nirmata#values) |
+| kyverno.helm | object | `nil` | Free form yaml section with helm parameters in Kyverno chart. Note that null values for any object in a yaml node must be specified using a special string "NULLOBJ" for that node. See all parameters [here](https://github.com/nirmata/kyverno-charts/tree/main/charts/nirmata#values). |
 | policies.policySets | list | `{pod-security-restricted, rbac-best-practices}` | Default policy sets to be installed along with operator. Others are, `pod-security-baseline`, `k8s-best-practices`, and `multitenancy-best-practices` |
 | awsAdapter.rbac.create | bool | false | Create RBAC resources for Kyverno AWS Adapter, if AWS Adapter is going to be enabled now (through the awsAdapter.createCR helm param below) or later |
 | awsAdapter.createCR | bool | false | Enable AWS Adapter by creating its Adapter Config CR |

--- a/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
+++ b/charts/enterprise-kyverno-operator/templates/cr-kyverno.yaml
@@ -31,7 +31,7 @@ spec:
               {{- end }}
         
       {{- if eq .Values.cloudPlatform "openshift" }}
-      securityContext: null
+      securityContext: NULLOBJ
       {{- end}}
 
       {{- if eq .Values.cloudPlatform "aks" }}

--- a/charts/enterprise-kyverno-operator/templates/pre-delete-hook.yaml
+++ b/charts/enterprise-kyverno-operator/templates/pre-delete-hook.yaml
@@ -24,7 +24,9 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 3000
+        {{- if .Values.podSecurityContext -}}
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- end }}
       containers:
         - name: kubectl
           image: {{ .Values.predeletehookimage | default "ghcr.io/nirmata/kubectl:1.24" }}


### PR DESCRIPTION
Provide string NULLOBJ instead of null due to issues described in the ticket. Also fix a related issue where the pre-delete hook fails if operator chart is installed with podSecurityContext=null. 