### PR TITLE
fix: remove duplicate labels

### DIFF
--- a/charts/nirmata/Chart.yaml
+++ b/charts/nirmata/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: kyverno
-version: 1.6.9
+version: 1.6.10
 appVersion: v1.9.5-n4k.nirmata.2
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management

--- a/charts/nirmata/README.md
+++ b/charts/nirmata/README.md
@@ -295,7 +295,7 @@ The following table lists the configurable parameters of the kyverno chart and t
 | licenceManager.productName | string | | Product name to be present in license, ignore product name check if empty |
 | licenceManager.validateIntervalMins | int | `60` | License validation interval in mins|
 | licenceManager.callHomeServer | string | `nirmata.io` | License server hostname:port |
-| licenceManager.licenseKey | string | | License key (required) |
+| licenceManager.licenseKey | string | `free-tier-license` | License key (required) |
 | licenceManager.apiKey | string | | License server API key |
 | licenceManager.clusterId | string | | Cluster Id to use. If not provided, uid of kube-system namnespace |
 | licenceManager.clusterName | string | | Cluster Name to use. Auto-generated if not provided |

--- a/charts/nirmata/templates/_helpers.tpl
+++ b/charts/nirmata/templates/_helpers.tpl
@@ -63,9 +63,6 @@ app.kubernetes.io/part-of: {{ template "kyverno.name" . }}
 {{/* Helm required labels */}}
 {{- define "kyverno.labels" -}}
 app.kubernetes.io/component: kyverno
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/name: {{ template "kyverno.name" . }}
 {{- with (include "kyverno.helmLabels" .) }}
 {{ . }}
 {{- end }}
@@ -73,8 +70,6 @@ app.kubernetes.io/name: {{ template "kyverno.name" . }}
 {{ . }}
 {{- end }}
 app.kubernetes.io/part-of: {{ template "kyverno.name" . }}
-app.kubernetes.io/version: "{{ .Chart.Version }}"
-helm.sh/chart: {{ template "kyverno.chart" . }}
 {{- with (include "kyverno.versionLabels" .) }}
 {{ . }}
 {{- end }}
@@ -91,11 +86,9 @@ helm.sh/chart: {{ template "kyverno.chart" . }}
 app: kyverno
 app.kubernetes.io/component: kyverno
 app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ template "kyverno.name" . }}-test
 app.kubernetes.io/part-of: {{ template "kyverno.name" . }}
 app.kubernetes.io/version: "{{ .Chart.Version | replace "+" "_" }}"
-helm.sh/chart: {{ template "kyverno.chart" . }}
 {{- end -}}
 
 {{/* matchLabels */}}

--- a/charts/nirmata/values.yaml
+++ b/charts/nirmata/values.yaml
@@ -39,7 +39,7 @@ image:
   repository: ghcr.io/nirmata/kyverno
   # -- Image tag
   # Defaults to appVersion in Chart.yaml if omitted
-  tag: v1.9.5-n4k.nirmata.1
+  tag: v1.9.5-n4k.nirmata.2
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Image pull secrets
@@ -55,7 +55,7 @@ initImage:
   repository: ghcr.io/nirmata/kyvernopre
   # -- Image tag
   # If initImage.tag is missing, defaults to image.tag
-  tag: v1.9.5-n4k.nirmata.1
+  tag: v1.9.5-n4k.nirmata.2
   # -- Image pull policy
   # If initImage.pullPolicy is missing, defaults to image.pullPolicy
   pullPolicy:
@@ -511,7 +511,7 @@ licenseManager:
   # -- License server
   callHomeServer: "nirmata.io"
   # -- License key
-  licenseKey:
+  licenseKey: "free-tier-license"
   # -- License server API key
   apiKey:
   # -- Cluster Id. If not provided, use kube-system uid
@@ -563,7 +563,7 @@ cleanupController:
     repository: ghcr.io/nirmata/cleanup-controller  # kyverno: replaced in e2e tests
     # -- Image tag
     # Defaults to appVersion in Chart.yaml if omitted
-    tag: v1.9.5-n4k.nirmata.1
+    tag: v1.9.5-n4k.nirmata.2
     # -- Image pull policy
     pullPolicy: IfNotPresent
     # -- Image pull secrets


### PR DESCRIPTION
Some labels were applied twice due to being directly as well as indirectly.
Also fixed a couple of minor issues regarding default license key and build (match what operator has).