### PR TITLE
NDEV-17828 upgrade n4k with golang cve fix

### DIFF
--- a/charts/enterprise-kyverno-operator/Chart.yaml
+++ b/charts/enterprise-kyverno-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: enterprise-kyverno-operator
 description: Helm Chart for Enterprise Kyverno Operator
 type: application
 
-version: v0.2.39
+version: v0.2.40
 appVersion: v0.1.18
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png

--- a/charts/enterprise-kyverno-operator/README.md
+++ b/charts/enterprise-kyverno-operator/README.md
@@ -110,7 +110,7 @@ There are platform specific configurations in which the Kyverno Helm chart confi
 | kyverno.generatecontrollerExtraResources | list | `[]` | Additional resources to be added to kyverno controller RBAC permissions |
 | kyverno.image.repository | string | `"ghcr.io/nirmata/kyverno"` | Kyverno Image repository |
 | kyverno.image.pullPolicy | string | `"IfNotPresent"` | Kyverno Image pull policy |
-| kyverno.image.tag | string | `v1.9.5-n4k.nirmata.3` | Image tag (defaults to chart app version) |
+| kyverno.image.tag | string | `v1.9.5-n4k.nirmata.4` | Image tag (defaults to chart app version) |
 | kyverno.enablePolicyExceptions| bool | `true` | Enable policyexceptions feature in Kyverno 1.9+ |
 | kyverno.excludedNamespacesForWebhook | list | `[]` | Namespaces to exclude from Kyverno webhook, in addition to defaults kyverno, kube-system, nirmata, nirmata-system |
 | kyverno.excludedNamespacesOverride | bool | `false` | Override exclusion of default namespaces in excludedNamespacesForWebhook parameter above|

--- a/charts/enterprise-kyverno-operator/values.yaml
+++ b/charts/enterprise-kyverno-operator/values.yaml
@@ -81,7 +81,7 @@ kyverno:
     # -- Image repository
     repository: ghcr.io/nirmata/kyverno
     # -- Image tag
-    tag: v1.9.5-n4k.nirmata.3
+    tag: v1.9.5-n4k.nirmata.4
 
   # -- Override default exclude namespaces (default kyverno, kube-system, nirmata, nirmata-system )
   excludedNamespacesForWebhook: []

--- a/charts/nirmata/Chart.yaml
+++ b/charts/nirmata/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: kyverno
-version: 1.6.11
-appVersion: v1.9.5-n4k.nirmata.3
+version: 1.6.12
+appVersion: v1.9.5-n4k.nirmata.4
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management
 keywords:

--- a/charts/nirmata/values.yaml
+++ b/charts/nirmata/values.yaml
@@ -39,7 +39,7 @@ image:
   repository: ghcr.io/nirmata/kyverno
   # -- Image tag
   # Defaults to appVersion in Chart.yaml if omitted
-  tag: v1.9.5-n4k.nirmata.3
+  tag: v1.9.5-n4k.nirmata.4
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Image pull secrets
@@ -55,7 +55,7 @@ initImage:
   repository: ghcr.io/nirmata/kyvernopre
   # -- Image tag
   # If initImage.tag is missing, defaults to image.tag
-  tag: v1.9.5-n4k.nirmata.3
+  tag: v1.9.5-n4k.nirmata.4
   # -- Image pull policy
   # If initImage.pullPolicy is missing, defaults to image.pullPolicy
   pullPolicy:
@@ -563,7 +563,7 @@ cleanupController:
     repository: ghcr.io/nirmata/cleanup-controller  # kyverno: replaced in e2e tests
     # -- Image tag
     # Defaults to appVersion in Chart.yaml if omitted
-    tag: v1.9.5-n4k.nirmata.3
+    tag: v1.9.5-n4k.nirmata.4
     # -- Image pull policy
     pullPolicy: IfNotPresent
     # -- Image pull secrets


### PR DESCRIPTION
Update default kyverno build in helm chart for Kyverno 1.9.5 to v1.9.5-n4k.nirmata.4, corresponding to N4K PR https://github.com/nirmata/kyverno/pull/60.