### PR TITLE
NDEV-17828 upgrade n4k with golang cve fix

### DIFF
--- a/charts/enterprise-kyverno-operator/Chart.yaml
+++ b/charts/enterprise-kyverno-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nirmata-kyverno-operator
 description: Helm Chart for Enterprise Kyverno Operator
 type: application
-version: v0.3.3
+version: v0.3.4
 appVersion: v0.2.0
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png

--- a/charts/enterprise-kyverno-operator/README.md
+++ b/charts/enterprise-kyverno-operator/README.md
@@ -168,7 +168,7 @@ There are platform specific configurations in which the Kyverno Helm chart confi
 | kyverno.generatecontrollerExtraResources | list | `[]` | Additional resources to be added to kyverno controller RBAC permissions |
 | kyverno.image.repository | string | `"ghcr.io/nirmata/kyverno"` | Kyverno Image repository |
 | kyverno.image.pullPolicy | string | `"IfNotPresent"` | Kyverno Image pull policy |
-| kyverno.image.tag | string | `v1.10.3-n4k.nirmata.3` | Image tag (defaults to chart app version) |
+| kyverno.image.tag | string | `v1.10.3-n4k.nirmata.4` | Image tag (defaults to chart app version) |
 | kyverno.enablePolicyExceptions| bool | `true` | Enable policyexceptions feature in Kyverno 1.9+ |
 | kyverno.excludedNamespacesForWebhook | list | `[]` | Namespaces to exclude from Kyverno webhook, in addition to defaults kyverno, kube-system, nirmata, nirmata-system |
 | kyverno.excludedNamespacesOverride | bool | `false` | Override exclusion of default namespaces in excludedNamespacesForWebhook parameter above|

--- a/charts/enterprise-kyverno-operator/values.yaml
+++ b/charts/enterprise-kyverno-operator/values.yaml
@@ -122,7 +122,7 @@ kyverno:
     # -- Image repository
     repository: ghcr.io
     # -- Image tag
-    tag: v1.10.3-n4k.nirmata.3
+    tag: v1.10.3-n4k.nirmata.4
 
   # -- Override default exclude namespaces (default kyverno, kube-system, nirmata, nirmata-system )
   excludedNamespacesForWebhook: []

--- a/charts/nirmata/Chart.yaml
+++ b/charts/nirmata/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: kyverno
-version: 3.0.5-rc4
-appVersion: v1.10.3-n4k.nirmata.3
+version: 3.0.5-rc5
+appVersion: v1.10.3-n4k.nirmata.4
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management
 keywords:

--- a/charts/nirmata/README.md
+++ b/charts/nirmata/README.md
@@ -2,7 +2,7 @@
 
 Kubernetes Native Policy Management
 
-![Version: 3.0.5-rc2](https://img.shields.io/badge/Version-3.0.5--rc2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.10.3-n4k.nirmata.3](https://img.shields.io/badge/AppVersion-v1.10.3--n4k.nirmata.2-informational?style=flat-square)
+![Version: 3.0.5-rc2](https://img.shields.io/badge/Version-3.0.5--rc2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.10.3-n4k.nirmata.4](https://img.shields.io/badge/AppVersion-v1.10.3--n4k.nirmata.2-informational?style=flat-square)
 
 ## About
 


### PR DESCRIPTION
Upgrade default kyverno and operator charts to use the kyverno build v1.10.3-n4k.nirmata.4, that contains fixes for the golang CVE. Corresponds to PR https://github.com/nirmata/kyverno/pull/59