### PR TITLE
change post upgrade

### DIFF
--- a/charts/enterprise-kyverno-operator/Chart.yaml
+++ b/charts/enterprise-kyverno-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nirmata-kyverno-operator
 description: Helm Chart for Enterprise Kyverno Operator
 type: application
-version: v0.4.0-rc5.3
+version: v0.4.0-rc5.4
 appVersion: v0.3.0-rc2
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png

--- a/charts/enterprise-kyverno-operator/templates/post-kyverno-upgrade.yaml
+++ b/charts/enterprise-kyverno-operator/templates/post-kyverno-upgrade.yaml
@@ -26,27 +26,26 @@ spec:
             - sh
             - -c
             - |
-              NAMESPACES=$(kubectl get namespaces --no-headers=true --output=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+              NAMESPACES=$(kubectl get namespaces --no-headers=true | awk '{print $1}')
 
-              for ns in $(echo $NAMESPACES);
-              do
-                COUNT=$(kubectl get policyreports.wgpolicyk8s.io -n $ns --no-headers=true --output=name | awk '/pol/{print $1}' | wc -l)
+              for ns in $NAMESPACES; do
+                  COUNT=$(kubectl get policyreports.wgpolicyk8s.io -n "$ns" --no-headers=true | awk '/pol/{print $1}' | wc -l)
 
-                if [ $COUNT -gt 0 ]; then
-                  echo "deleting $COUNT policyreports in namespace $ns"
-                  kubectl get policyreports.wgpolicyk8s.io -n $ns --no-headers=true --output=name | awk '/pol/{print $1}' | xargs kubectl delete -n $ns
-                else
-                  echo "no policyreports in namespace $ns"
-                fi
+                  if [ "$COUNT" -gt 0 ]; then
+                      echo "deleting $COUNT policyreports in namespace $ns"
+                      kubectl get policyreports.wgpolicyk8s.io -n "$ns" --no-headers=true | awk '/pol/{print $1}' | xargs kubectl delete -n "$ns" policyreports.wgpolicyk8s.io
+                  else
+                      echo "no policyreports in namespace $ns"
+                  fi
               done
 
-              COUNT=$(kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true --output=name | awk '/pol/{print $1}' | wc -l)
-                            
-              if [ $COUNT -gt 0 ]; then
-                echo "deleting $COUNT clusterpolicyreports"
-                kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true --output=name | awk '/pol/{print $1}' | xargs kubectl delete
+              COUNT=$(kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true | awk '/pol/{print $1}' | wc -l)
+
+              if [ "$COUNT" -gt 0 ]; then
+                  echo "deleting $COUNT clusterpolicyreports"
+                  kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true | awk '/pol/{print $1}' | xargs kubectl delete clusterpolicyreports.wgpolicyk8s.io
               else
-                echo "no clusterpolicyreports"
+                  echo "no clusterpolicyreports"
               fi
           {{- with .Values.kyverno.helm.policyReportsCleanup.securityContext }}
           securityContext:

--- a/charts/enterprise-kyverno-operator/templates/post-kyverno-upgrade.yaml
+++ b/charts/enterprise-kyverno-operator/templates/post-kyverno-upgrade.yaml
@@ -26,25 +26,25 @@ spec:
             - sh
             - -c
             - |
-              NAMESPACES=$(kubectl get namespaces --no-headers=true | awk '{print $1}')
+              NAMESPACES=$(kubectl get namespaces --no-headers=true --output=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
 
-              for ns in ${NAMESPACES[@]};
+              for ns in $(echo $NAMESPACES);
               do
-                COUNT=$(kubectl get policyreports.wgpolicyk8s.io -n $ns --no-headers=true | awk '/pol/{print $1}' | wc -l)
+                COUNT=$(kubectl get policyreports.wgpolicyk8s.io -n $ns --no-headers=true --output=name | awk '/pol/{print $1}' | wc -l)
 
                 if [ $COUNT -gt 0 ]; then
                   echo "deleting $COUNT policyreports in namespace $ns"
-                  kubectl get policyreports.wgpolicyk8s.io -n $ns --no-headers=true | awk '/pol/{print $1}' | xargs kubectl delete -n $ns policyreports.wgpolicyk8s.io
+                  kubectl get policyreports.wgpolicyk8s.io -n $ns --no-headers=true --output=name | awk '/pol/{print $1}' | xargs kubectl delete -n $ns
                 else
                   echo "no policyreports in namespace $ns"
                 fi
               done
 
-              COUNT=$(kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true | awk '/pol/{print $1}' | wc -l)
-                
+              COUNT=$(kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true --output=name | awk '/pol/{print $1}' | wc -l)
+                            
               if [ $COUNT -gt 0 ]; then
                 echo "deleting $COUNT clusterpolicyreports"
-                kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true | awk '/pol/{print $1}' | xargs kubectl delete clusterpolicyreports.wgpolicyk8s.io
+                kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true --output=name | awk '/pol/{print $1}' | xargs kubectl delete
               else
                 echo "no clusterpolicyreports"
               fi

--- a/charts/nirmata/Chart.yaml
+++ b/charts/nirmata/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: kyverno
-version: 3.1.7
+version: 3.1.8-rc1
 appVersion: v1.11.4-n4k.nirmata.3
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management

--- a/charts/nirmata/templates/hooks/post-upgrade.yaml
+++ b/charts/nirmata/templates/hooks/post-upgrade.yaml
@@ -28,27 +28,26 @@ spec:
           - sh
           - -c
           - |
-              NAMESPACES=$(kubectl get namespaces --no-headers=true --output=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+              NAMESPACES=$(kubectl get namespaces --no-headers=true | awk '{print $1}')
 
-              for ns in $(echo $NAMESPACES);
-              do
-                COUNT=$(kubectl get policyreports.wgpolicyk8s.io -n $ns --no-headers=true --output=name | awk '/pol/{print $1}' | wc -l)
+              for ns in $NAMESPACES; do
+                  COUNT=$(kubectl get policyreports.wgpolicyk8s.io -n "$ns" --no-headers=true | awk '/pol/{print $1}' | wc -l)
 
-                if [ $COUNT -gt 0 ]; then
-                  echo "deleting $COUNT policyreports in namespace $ns"
-                  kubectl get policyreports.wgpolicyk8s.io -n $ns --no-headers=true --output=name | awk '/pol/{print $1}' | xargs kubectl delete -n $ns
-                else
-                  echo "no policyreports in namespace $ns"
-                fi
+                  if [ "$COUNT" -gt 0 ]; then
+                      echo "deleting $COUNT policyreports in namespace $ns"
+                      kubectl get policyreports.wgpolicyk8s.io -n "$ns" --no-headers=true | awk '/pol/{print $1}' | xargs kubectl delete -n "$ns" policyreports.wgpolicyk8s.io
+                  else
+                      echo "no policyreports in namespace $ns"
+                  fi
               done
 
-              COUNT=$(kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true --output=name | awk '/pol/{print $1}' | wc -l)
-                            
-              if [ $COUNT -gt 0 ]; then
-                echo "deleting $COUNT clusterpolicyreports"
-                kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true --output=name | awk '/pol/{print $1}' | xargs kubectl delete
+              COUNT=$(kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true | awk '/pol/{print $1}' | wc -l)
+
+              if [ "$COUNT" -gt 0 ]; then
+                  echo "deleting $COUNT clusterpolicyreports"
+                  kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true | awk '/pol/{print $1}' | xargs kubectl delete clusterpolicyreports.wgpolicyk8s.io
               else
-                echo "no clusterpolicyreports"
+                  echo "no clusterpolicyreports"
               fi
           {{- with .Values.policyReportsCleanup.securityContext }}
           securityContext:

--- a/charts/nirmata/templates/hooks/post-upgrade.yaml
+++ b/charts/nirmata/templates/hooks/post-upgrade.yaml
@@ -28,25 +28,25 @@ spec:
           - sh
           - -c
           - |
-              NAMESPACES=$(kubectl get namespaces --no-headers=true | awk '{print $1}')
+              NAMESPACES=$(kubectl get namespaces --no-headers=true --output=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
 
-              for ns in ${NAMESPACES[@]};
+              for ns in $(echo $NAMESPACES);
               do
-                COUNT=$(kubectl get policyreports.wgpolicyk8s.io -n $ns --no-headers=true | awk '/pol/{print $1}' | wc -l)
+                COUNT=$(kubectl get policyreports.wgpolicyk8s.io -n $ns --no-headers=true --output=name | awk '/pol/{print $1}' | wc -l)
 
                 if [ $COUNT -gt 0 ]; then
                   echo "deleting $COUNT policyreports in namespace $ns"
-                  kubectl get policyreports.wgpolicyk8s.io -n $ns --no-headers=true | awk '/pol/{print $1}' | xargs kubectl delete -n $ns policyreports.wgpolicyk8s.io
+                  kubectl get policyreports.wgpolicyk8s.io -n $ns --no-headers=true --output=name | awk '/pol/{print $1}' | xargs kubectl delete -n $ns
                 else
                   echo "no policyreports in namespace $ns"
                 fi
               done
 
-              COUNT=$(kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true | awk '/pol/{print $1}' | wc -l)
-                
+              COUNT=$(kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true --output=name | awk '/pol/{print $1}' | wc -l)
+                            
               if [ $COUNT -gt 0 ]; then
                 echo "deleting $COUNT clusterpolicyreports"
-                kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true | awk '/pol/{print $1}' | xargs kubectl delete clusterpolicyreports.wgpolicyk8s.io
+                kubectl get clusterpolicyreports.wgpolicyk8s.io --no-headers=true --output=name | awk '/pol/{print $1}' | xargs kubectl delete
               else
                 echo "no clusterpolicyreports"
               fi


### PR DESCRIPTION
I still faced issues with substitution
```
nirmata ) k logs -n kyverno po/kyverno-hook-post-upgrade-k46zh                                                                Thu Feb 29 16:31:50 2024
sh: syntax error: bad substitution
```
I suspect it is because the script upstream is written to run in bash and we are running in sh.
I have changed everything that could have caused the substitution issue.