### PR TITLE
NDEV-18668 preserve multiple certs

### DIFF
--- a/charts/venafi-adapter/Chart.yaml
+++ b/charts/venafi-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: venafi-adapter
-version: v0.1.14
+version: v0.1.15
 appVersion: v0.1.0
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Nirmata Venafi Adapter

--- a/charts/venafi-adapter/values.yaml
+++ b/charts/venafi-adapter/values.yaml
@@ -29,3 +29,5 @@ systemCertPath: /etc/ssl/certs
 # - name: HTTPS_PROXY
 #   value: https://test.com:8000
 extraEnvVars:
+- name: VENAFI_PKCS11_CLIENT_IMAGE
+  value: ghcr.io/nirmata/venafi-pkcs11-client:0.3.1


### PR DESCRIPTION
Exposing an environment variable to allow specification of a specific version of venafi pkcs11 client to imagekey controller. The new venafi pkcs11 client version specified has the ability to preserve multiple certificates. 