### PR TITLE
NDEV-19725 : Ebay wildcard clusterrole error fix 1.10

### DIFF
--- a/charts/nirmata/Chart.yaml
+++ b/charts/nirmata/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: kyverno
 
-version: 3.0.31-rc4
+version: 3.0.31-rc5
 appVersion: v1.10.7-n4k.nirmata.15
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png

--- a/charts/nirmata/templates/admission-controller/clusterrole.yaml
+++ b/charts/nirmata/templates/admission-controller/clusterrole.yaml
@@ -99,6 +99,28 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
+  - apiGroups:
+      - ""
+    resources:
+      - "nodes"
+    verbs:
+      - list
+
+  - apiGroups:
+      - ""
+    resources:
+      - "namespaces"
+    verbs:
+      - list
+      - get
+
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - "customresourcedefinitions"
+    verbs:
+      - get
+
 {{- with .Values.admissionController.rbac.coreClusterRole.extraResources }}
   {{- toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/nirmata/templates/background-controller/clusterrole.yaml
+++ b/charts/nirmata/templates/background-controller/clusterrole.yaml
@@ -79,6 +79,12 @@ rules:
       - update
       - patch
       - delete
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - "customresourcedefinitions"
+    verbs:
+      - get
 {{- with .Values.backgroundController.rbac.coreClusterRole.extraResources }}
   {{- toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/nirmata/templates/cleanup-controller/clusterrole.yaml
+++ b/charts/nirmata/templates/cleanup-controller/clusterrole.yaml
@@ -89,6 +89,12 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - "customresourcedefinitions"
+    verbs:
+      - get
 {{- with .Values.cleanupController.rbac.coreClusterRole.extraResources }}
   {{- toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/nirmata/templates/reports-controller/clusterrole.yaml
+++ b/charts/nirmata/templates/reports-controller/clusterrole.yaml
@@ -63,6 +63,12 @@ rules:
     verbs:
       - create
       - patch
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - "customresourcedefinitions"
+    verbs:
+      - get
 {{- with .Values.admissionController.rbac.coreClusterRole.extraResources }}
   {{- toYaml . | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
The kyverno admission controller, cleanup controller, reports controller and background controller were crashing unexpectedly upon omitting the wildcard perms in clusterroles of these controllers, this PR aims to fix this issue.

[Jira](https://nirmata.atlassian.net/browse/NDEV-19725)