### PR TITLE
Remove `apiTokenSecret` from Helm values

### DIFF
--- a/charts/nirmata-kube-controller/Chart.yaml
+++ b/charts/nirmata-kube-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nirmata-kube-controller/values.yaml
+++ b/charts/nirmata-kube-controller/values.yaml
@@ -10,6 +10,7 @@ cluster:
   type: "default-policy-manager-type"
 
 # Use either apiToken or apiTokenSecret to specify the api token in NPM
+
 # to use the apiTokenSecret, please create a secret with key 'apiKey'
 # here's the example
 # apiVersion: v1
@@ -20,7 +21,8 @@ cluster:
 # data:
 #   apiKey: "{base64 encoded api token}"
 
-apiTokenSecret: "nirmata-api-token"
+# apiTokenSecret: "nirmata-api-token"
+
 # to use apiToken, please specify the token directly, no base64 encode needed
 # apiToken: ""
 


### PR DESCRIPTION
The `apiTokenSecret` field has been removed from the values file as it does not need to be overridden with each deployment.