### PR TITLE
NDEV-20747 : GA charts for n4k-1.12.6-n4k.nirmata.3

### DIFF
--- a/charts/nirmata/Chart.yaml
+++ b/charts/nirmata/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: kyverno
-version: 3.2.9-rc2
-appVersion: v1.12.6-n4k.nirmata.3-rc7
+version: 3.2.9
+appVersion: v1.12.6-n4k.nirmata.3
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management
 keywords:


### PR DESCRIPTION
This PR releases the GA charts for n4k-1.12.6-n4k.nirmata.3 with the `dumpPatch` flag support added, as well as CVE fixes.