### PR TITLE
GA chart 3.3.4 containing disableAutoWebhookGeneration flag

### DIFF
--- a/charts/nirmata/Chart.yaml
+++ b/charts/nirmata/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: kyverno
-version: 3.3.4-rc1
-appVersion: v1.13.2-n4k.nirmata.4-rc1
+version: 3.3.4
+appVersion: v1.13.2-n4k.nirmata.4
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management
 keywords:


### PR DESCRIPTION
This PR is to release GA charts for n4k-1.13 patch release which contains the disableAutoWebhookGeneration flag as well as CVE fixes.

Build is in progress: https://github.com/nirmata/enterprise-kyverno/actions/runs/13050525232

Once build is complete we can merge this PR.