### PR TITLE
fix: clusterlabels and included imagePullSecrets and apiTokenSecret

### DIFF
--- a/charts/nirmata-kube-controller/Chart.yaml
+++ b/charts/nirmata-kube-controller/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7-rc3
+version: 0.1.7-rc4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.10.7"
+appVersion: "v3.10.9"
 
 maintainers:
   - name: Nirmata

--- a/charts/nirmata-kube-controller/templates/_helpers.tpl
+++ b/charts/nirmata-kube-controller/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "controller.imagePullSecret" }}
+{{- printf "{\"auths\":{\"%s\":{\"auth\":\"%s\"}}}" .imageRegistry (printf "%s:%s" .registryUserName .registryPassword | b64enc) | b64enc }}
+{{- end }}

--- a/charts/nirmata-kube-controller/templates/apiTokenSecret.yaml
+++ b/charts/nirmata-kube-controller/templates/apiTokenSecret.yaml
@@ -1,0 +1,10 @@
+
+{{ if .Values.apiToken }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nirmata-api-token
+  namespace: nirmata
+data:
+  apiKey: {{ .Values.apiToken | b64enc }}
+{{ end }}

--- a/charts/nirmata-kube-controller/templates/imagePullSecret.yaml
+++ b/charts/nirmata-kube-controller/templates/imagePullSecret.yaml
@@ -1,0 +1,11 @@
+{{ if and .Values.global.imageRegistry .Values.global.registryUserName .Values.global.registryPassword }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nirmata-controller-registry-secret
+  namespace: {{ .Values.namespace }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "controller.imagePullSecret" .Values.global }}
+{{ end }}

--- a/charts/nirmata-kube-controller/templates/nirmata-kube-controller.yaml
+++ b/charts/nirmata-kube-controller/templates/nirmata-kube-controller.yaml
@@ -390,18 +390,12 @@ spec:
         - 10m
         - -cluster-name
         - {{ .Values.cluster.name }}
-        {{- if .Values.apiToken }}
-        - -api-token
-        - {{ .Values.apiToken }}
-        {{- end }}
         {{ range $key, $value := .Values.cluster.labels }}
         - "-cluster-labels"
         - "{{ $key }}:{{ $value }}"
         {{ end }}
-        {{- if .Values.apiTokenSecret }}
         - -api-token-secret
-        - {{ .Values.apiTokenSecret }}
-        {{- end }}
+        - nirmata-api-token
         command:
         - /nirmata-kube-controller
         env:

--- a/charts/nirmata-kube-controller/values.yaml
+++ b/charts/nirmata-kube-controller/values.yaml
@@ -2,10 +2,13 @@
 # # This is a YAML-formatted file.
 # # Declare variables to be passed into your templates.
 
-nirmataURL: "wss://nirmata.io/tunnels"
+nirmataURL: "wss://nirmata.co/tunnels"
+namespace: "nirmata"
 global:
   imageRegistry: ghcr.io
   imageRepository: nirmata
+  registryUserName:
+  registryPassword:
 
 kubeController:
   imageRegistry:
@@ -22,23 +25,10 @@ cluster:
   type: default-policy-manager-type
   labels:
     # key: value
+    # key2: value2
 
-# Use either apiToken or apiTokenSecret to specify the api token in NPM
+apiToken: ""
 
-# to use the apiTokenSecret, please create a secret with key 'apiKey'
-# here's the example
-# apiVersion: v1
-# kind: Secret
-# metadata:
-#   name: nirmata-api-token
-#   namespace: nirmata
-# data:
-#   apiKey: "{base64 encoded api token}"
-
-# apiTokenSecret: "nirmata-api-token"
-
-# to use apiToken, please specify the token directly, no base64 encode needed
-# apiToken: ""
 features:
   policyExceptions:
     enabled: false

--- a/charts/nirmata-kube-controller/values.yaml
+++ b/charts/nirmata-kube-controller/values.yaml
@@ -2,7 +2,7 @@
 # # This is a YAML-formatted file.
 # # Declare variables to be passed into your templates.
 
-nirmataURL: "wss://nirmata.co/tunnels"
+nirmataURL: "wss://nirmata.io/tunnels"
 namespace: "nirmata"
 global:
   imageRegistry: ghcr.io


### PR DESCRIPTION
<img width="590" alt="Screenshot 2025-03-01 at 11 24 49 AM" src="https://github.com/user-attachments/assets/471a584d-f36d-4f61-b90e-be8ee856302f" />




here is the imagePullSecret being generated when we mention `.Values.global.imageRegistry` `.Values.global.registryUserNmae` and `.Values.global.registryPassword`

```
apiVersion: v1
kind: Secret
metadata:
  name: nirmata-controller-registry-secret
  namespace: nirmata
type: kubernetes.io/dockerconfigjson
data:
  .dockerconfigjson: eyJhdXRocyI6eyJnaGNyLmlvIjp7ImF1dGgiOiJkWE5sY2pwaFpHMXBiZz09In19fQ==
```
