### PR TITLE
add annotations to kube controller deployment

### DIFF
--- a/charts/nirmata-kube-controller/Chart.yaml
+++ b/charts/nirmata-kube-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.1.9-rc1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nirmata-kube-controller/templates/nirmata-kube-controller.yaml
+++ b/charts/nirmata-kube-controller/templates/nirmata-kube-controller.yaml
@@ -365,6 +365,24 @@ kind: Deployment
 metadata:
   name: nirmata-kube-controller
   namespace: nirmata
+  annotations:
+    nirmata.io/namespace: {{ .Values.namespace | quote }}
+    nirmata.io/cluster-name: {{ .Values.cluster.name | quote }}
+    nirmata.io/cluster-type: {{ .Values.cluster.type | quote }}
+    nirmata.io/read-write-mode: {{ .Values.readWriteMode | quote }}
+    nirmata.io/features.policy-exceptions: {{ .Values.features.policyExceptions.enabled | quote }}
+    nirmata.io/features.policy-sets: {{ .Values.features.policySets.enabled | quote }}
+    nirmata.io/chart-version: {{ .Chart.Version | quote }}
+    nirmata.io/app-version: {{ .Chart.AppVersion | quote }}
+    {{- if .Values.proxy.httpProxy }}
+    nirmata.io/proxy/http: {{ .Values.proxy.httpProxy | quote }}
+    {{- end }}
+    {{- if .Values.proxy.httpsProxy }}
+    nirmata.io/proxy/https: {{ .Values.proxy.httpsProxy | quote }}
+    {{- end }}
+    {{- if .Values.proxy.noProxy }}
+    nirmata.io/proxy/no-proxy: {{ .Values.proxy.noProxy | quote }}
+    {{- end }}
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
The kube-controller deployment can be fetched in operator or kube-controller CR or directly from NCH and it shall have annotations depicting the values overwritten by the user so that we can store this config eventually in NCH to show to the user.

[Detailed design doc](https://docs.google.com/document/d/1mszSfJKnb20i-daE4Y9TD_DQpDaMQx_odwrLtOIvqT0/edit?tab=t.0#heading=h.dlxcok4qhw6l)