### PR TITLE
add read only permission for kube controller deployment

### DIFF
--- a/charts/nirmata-kube-controller/Chart.yaml
+++ b/charts/nirmata-kube-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.9-rc2
+version: 0.1.9-rc3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nirmata-kube-controller/templates/nirmata-kube-controller.yaml
+++ b/charts/nirmata-kube-controller/templates/nirmata-kube-controller.yaml
@@ -335,6 +335,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  resourceNames:
+  - nirmata-kube-controller
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}
 ---
 apiVersion: v1


### PR DESCRIPTION
add read only permission for kube controller deployment in the read only cluster role so that NCH can get the deployment to update featurePermission model