### PR TITLE
NDEV-20261 | Removed exec probes from go-kube-controller deployment

### DIFF
--- a/charts/nirmata-kube-controller/Chart.yaml
+++ b/charts/nirmata-kube-controller/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.2.6
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nirmata-kube-controller/Chart.yaml
+++ b/charts/nirmata-kube-controller/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 3.10.10
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.10.9"
+appVersion: "v3.10.10"
 
 maintainers:
   - name: Nirmata

--- a/charts/nirmata-kube-controller/Chart.yaml
+++ b/charts/nirmata-kube-controller/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.2.7
+version: 3.10.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nirmata-kube-controller/templates/nirmata-kube-controller.yaml
+++ b/charts/nirmata-kube-controller/templates/nirmata-kube-controller.yaml
@@ -277,8 +277,6 @@ spec:
         {{- if .Values.kubeController.insecure }}
         - -insecure
         {{- end }}
-        command:
-        - /nirmata-kube-controller
         env:
         - name: URL
           value: {{ default "wss://nirmata.io/tunnels" .Values.nirmataURL }}
@@ -293,14 +291,18 @@ spec:
         image: "{{ .Values.global.imageRegistry }}/{{ .Values.global.imageRepository }}/nirmata-kube-controller:{{ .Values.kubeController.imageTag | default .Chart.AppVersion }}"
         imagePullPolicy: Always
         livenessProbe:
-          exec:
-            command:
-            - /nirmata-kube-controller
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 10
         name: nirmata-kube-controller
         readinessProbe:
-          exec:
-            command:
-            - /nirmata-kube-controller
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
         resources:
           limits:
             cpu: {{ .Values.kubeController.resources.limits.cpu }}


### PR DESCRIPTION
Replaced `exec` probe with `http`
Had to bump chart version to resolve below error:
```
Run ct lint --target-branch main
------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 nirmata-kube-controller => (version: "0.2.6", path: "charts/nirmata-kube-controller")
------------------------------------------------------------------------------------------------------------------------

Linting chart 'nirmata-kube-controller => (version: "0.2.6", path: "charts/nirmata-kube-controller")'
Checking chart 'nirmata-kube-controller => (version: "0.2.6", path: "charts/nirmata-kube-controller")' for a version bump...
Old chart version: 0.2.6
New chart version: 0.2.6
------------------------------------------------------------------------------------------------------------------------
 ✖︎ nirmata-kube-controller => (version: "0.2.6", path: "charts/nirmata-kube-controller") > Chart version not ok. Needs a version bump!
Error: Error linting charts: Error processing charts
------------------------------------------------------------------------------------------------------------------------
Error linting charts: Error processing charts
Error: Process completed with exit code 1.
```