### PR TITLE
feat: add restartPolicy parameter to cluster-registrator chart

### DIFF
--- a/charts/cluster-registrator/templates/job.yaml
+++ b/charts/cluster-registrator/templates/job.yaml
@@ -469,7 +469,7 @@ spec:
           seccompProfile:
             type: "RuntimeDefault"
       serviceAccountName: nirmata-cluster-registrator
-      restartPolicy: Never
+      restartPolicy: {{ .Values.registrator.restartPolicy | quote }}
   backoffLimit: 0
 ---
 {{- if not .Values.createNs }}

--- a/charts/cluster-registrator/values.yaml
+++ b/charts/cluster-registrator/values.yaml
@@ -29,6 +29,7 @@ registrator:
   image:
     registry: ""
     repository: ""
+  restartPolicy: "OnFailure"  # Can be either "OnFailure" or "Never"
 
 hooks:
   image:


### PR DESCRIPTION
The API secret token can be created after the kubecontroller deployment, which causes the deployment to never restart and wait indefinitely for the secret token. Adding the capability to choose the restart policy based on the method the user prefers... 
Please review