### PR TITLE
Sync chart from nirmata/go-kube-controller

### DIFF
--- a/charts/nirmata-kube-controller/Chart.yaml
+++ b/charts/nirmata-kube-controller/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.3.8-rc2
+version: 0.3.8-rc3
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/nirmata-kube-controller/templates/nirmata-kube-controller.yaml
+++ b/charts/nirmata-kube-controller/templates/nirmata-kube-controller.yaml
@@ -223,7 +223,6 @@ data:
     policies.v1.kyverno.io
     clusterpolicies.v1.kyverno.io
     policyexceptions.v2alpha1.kyverno.io
-    policyexceptions.v2beta1.kyverno.io
     policyexceptions.v2.kyverno.io
     policysets.v1alpha1.security.nirmata.io
     kyvernoconfigs.v1alpha1.security.nirmata.io


### PR DESCRIPTION
This PR syncs the updated Helm chart from `nirmata/go-kube-controller`.