### PR TITLE
define a single global kubectl image

### DIFF
--- a/charts/nirmata/templates/admission-controller/deployment.yaml
+++ b/charts/nirmata/templates/admission-controller/deployment.yaml
@@ -151,8 +151,8 @@ spec:
           {{- end }}
         {{- if eq (include "kyverno.installReportsServer" .) "true" }}
         - name: wait-for-reports-server
-          image: {{ .Values.global.kubectlImage }}
-          imagePullPolicy: IfNotPresent
+          image: {{ include "kyverno.image" (dict "globalRegistry" .Values.global.image.registry "image" .Values.global.kubectlImage "defaultTag" .Values.global.kubectlImage.tag) | quote }}
+          imagePullPolicy: {{ .Values.global.kubectlImage.pullPolicy }}
           command:
             - /bin/sh
             - -c

--- a/charts/nirmata/templates/background-controller/deployment.yaml
+++ b/charts/nirmata/templates/background-controller/deployment.yaml
@@ -88,8 +88,8 @@ spec:
       {{- if eq (include "kyverno.installReportsServer" .) "true" }}
       initContainers:
         - name: wait-for-reports-server
-          image: {{ .Values.global.kubectlImage }}
-          imagePullPolicy: IfNotPresent
+          image: {{ include "kyverno.image" (dict "globalRegistry" .Values.global.image.registry "image" .Values.global.kubectlImage "defaultTag" .Values.global.kubectlImage.tag) | quote }}
+          imagePullPolicy: {{ .Values.global.kubectlImage.pullPolicy }}
           command:
             - /bin/sh
             - -c

--- a/charts/nirmata/templates/hooks/post-delete-configmap.yaml
+++ b/charts/nirmata/templates/hooks/post-delete-configmap.yaml
@@ -91,8 +91,8 @@ spec:
       {{- end }}
       containers:
         - name: kubectl
-          image: {{ (include "kyverno.image" (dict "globalRegistry" .Values.global.image.registry "image" .Values.webhooksCleanup.image "defaultTag" (default .Chart.AppVersion .Values.webhooksCleanup.image.tag))) | quote }}
-          imagePullPolicy: {{ .Values.webhooksCleanup.image.pullPolicy }}
+          image: {{ include "kyverno.image" (dict "globalRegistry" .Values.global.image.registry "image" .Values.global.kubectlImage "defaultTag" .Values.global.kubectlImage.tag) | quote }}
+          imagePullPolicy: {{ .Values.global.kubectlImage.pullPolicy }}
           command:
             - /bin/bash
             - '-c'

--- a/charts/nirmata/templates/hooks/pre-delete-configmap.yaml
+++ b/charts/nirmata/templates/hooks/pre-delete-configmap.yaml
@@ -89,8 +89,8 @@ spec:
       {{- end }}
       containers:
         - name: kubectl
-          image: {{ (include "kyverno.image" (dict "globalRegistry" .Values.global.image.registry "image" .Values.webhooksCleanup.image "defaultTag" (default .Chart.AppVersion .Values.webhooksCleanup.image.tag))) | quote }}
-          imagePullPolicy: {{ .Values.webhooksCleanup.image.pullPolicy }}
+          image: {{ include "kyverno.image" (dict "globalRegistry" .Values.global.image.registry "image" .Values.global.kubectlImage "defaultTag" .Values.global.kubectlImage.tag) | quote }}
+          imagePullPolicy: {{ .Values.global.kubectlImage.pullPolicy }}
           command:
             - /bin/bash
             - '-c'

--- a/charts/nirmata/templates/hooks/pre-delete-scale-to-zero.yaml
+++ b/charts/nirmata/templates/hooks/pre-delete-scale-to-zero.yaml
@@ -41,8 +41,8 @@ spec:
       {{- end }}
       containers:
         - name: kubectl
-          image: {{ (include "kyverno.image" (dict "globalRegistry" .Values.global.image.registry "image" .Values.webhooksCleanup.image "defaultTag" (default .Chart.AppVersion .Values.webhooksCleanup.image.tag))) | quote }}
-          imagePullPolicy: {{ .Values.webhooksCleanup.image.pullPolicy }}
+          image: {{ include "kyverno.image" (dict "globalRegistry" .Values.global.image.registry "image" .Values.global.kubectlImage "defaultTag" .Values.global.kubectlImage.tag) | quote }}
+          imagePullPolicy: {{ .Values.global.kubectlImage.pullPolicy }}
           command:
             - kubectl
             - scale

--- a/charts/nirmata/templates/reports-controller/deployment.yaml
+++ b/charts/nirmata/templates/reports-controller/deployment.yaml
@@ -88,8 +88,8 @@ spec:
       {{- if eq (include "kyverno.installReportsServer" .) "true" }}
       initContainers:
         - name: wait-for-reports-server
-          image: {{ .Values.global.kubectlImage }}
-          imagePullPolicy: IfNotPresent
+          image: {{ include "kyverno.image" (dict "globalRegistry" .Values.global.image.registry "image" .Values.global.kubectlImage "defaultTag" .Values.global.kubectlImage.tag) | quote }}
+          imagePullPolicy: {{ .Values.global.kubectlImage.pullPolicy }}
           command:
             - /bin/sh
             - -c

--- a/charts/nirmata/values.yaml
+++ b/charts/nirmata/values.yaml
@@ -15,7 +15,16 @@ global:
   # When set, it will override any values set under `imagePullSecrets` under different components across the chart.
   imagePullSecrets: []
 
-  kubectlImage: "ghcr.io/nirmata/kubectl:1.33.2"
+  # -- Kubectl image configuration
+  kubectlImage:
+    # -- (string) Image registry
+    registry: reg.nirmata.io
+    # -- (string) Image repository
+    repository: nirmata/kubectl
+    # -- (string) Image tag
+    tag: "1.33.2"
+    # -- (string) Image pull policy
+    pullPolicy: IfNotPresent
 
   # -- Resync period for informers
   resyncPeriod: 15m
@@ -550,18 +559,6 @@ webhooksCleanup:
     # -- Allow webhooks controller to delete webhooks using finalizers
     enabled: false
 
-  image:
-    # -- (string) Image registry
-    registry: ~
-    # -- Image repository
-    repository: reg.nirmata.io/nirmata/kubectl
-    # -- Image tag
-    # Defaults to `latest` if omitted
-    tag: '1.32.1'
-    # -- (string) Image pull policy
-    # Defaults to image.pullPolicy if omitted
-    pullPolicy: ~
-
   # -- Image pull secrets
   imagePullSecrets: []
 
@@ -620,18 +617,6 @@ webhooksCleanup:
 policyReportsCleanup:
   # -- Create a helm post-upgrade hook to cleanup the old policy reports.
   enabled: true
-
-  image:
-    # -- (string) Image registry
-    registry: reg.nirmata.io
-    # -- Image repository
-    repository: nirmata/kubectl
-    # -- Image tag
-    # Defaults to `latest` if omitted
-    tag: '1.31.1'
-    # -- (string) Image pull policy
-    # Defaults to image.pullPolicy if omitted
-    pullPolicy: ~
 
   # -- Image pull secrets
   imagePullSecrets: []
@@ -2575,17 +2560,6 @@ reports-server:
 
 
   jobConfigurations:
-    image:
-      # -- (string) Image registry
-      registry: ghcr.io
-      # -- Image repository
-      repository: nirmata/kubectl
-      # -- Image tag
-      # Defaults to `latest` if omitted
-      tag: '1.30.2'
-      # -- (string) Image pull policy
-      # Defaults to image.pullPolicy if omitted
-      pullPolicy: ~
 
     # -- Image pull secrets
     imagePullSecrets: []


### PR DESCRIPTION
- update multiple references to kubectl image to a global reference.
- use the latest 1.33.2 version as the default.