### PR TITLE
Sync chart from nirmata/go-kube-controller

### DIFF
--- a/charts/nirmata-kube-controller/Chart.yaml
+++ b/charts/nirmata-kube-controller/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.3.8
+version: 0.3.9-rc1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/nirmata-kube-controller/templates/nirmata-kube-controller.yaml
+++ b/charts/nirmata-kube-controller/templates/nirmata-kube-controller.yaml
@@ -107,6 +107,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups: ["nirmata.io"]
+  resources:
+  - clusterconfigs
+  - clusterconfigs/status
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups: ["security.nirmata.io"]
   resources:
   - imagekeys
@@ -224,6 +232,7 @@ data:
     clusterpolicies.v1.kyverno.io
     policyexceptions.v2alpha1.kyverno.io
     policyexceptions.v2.kyverno.io
+    clusterconfigs.v1alpha1.nirmata.io
     policysets.v1alpha1.security.nirmata.io
     kyvernoconfigs.v1alpha1.security.nirmata.io
   IgnoreEvents: Normal.PolicyPlaceHolder.*


### PR DESCRIPTION
This PR syncs the updated Helm chart from `nirmata/go-kube-controller`.