### PR TITLE
Sync chart from nirmata/go-agent-remediator

### DIFF
--- a/charts/go-agent-remediator/templates/deployment.yaml
+++ b/charts/go-agent-remediator/templates/deployment.yaml
@@ -43,6 +43,13 @@ spec:
             {{- if or .Values.logging.enableAudit (gt (.Values.logging.verbosity | int) 0) }}
             - -v={{ max (.Values.logging.verbosity | int) (ternary 1 0 .Values.logging.enableAudit) }}
             {{- end }}
+            - --api-token-secret={{ .Values.nirmata.apiTokenSecret }}
+            {{- if .Values.nirmata.apiTokenSecretNamespace }}
+            - --api-token-secret-namespace={{ .Values.nirmata.apiTokenSecretNamespace }}
+            {{- end }}
+            {{- if .Values.nirmata.endpoint }}
+            - --url={{ .Values.nirmata.endpoint }}
+            {{- end }}
           ports:
             - containerPort: 8443
               name: metrics

--- a/charts/go-agent-remediator/templates/llmconfig.yaml
+++ b/charts/go-agent-remediator/templates/llmconfig.yaml
@@ -28,7 +28,7 @@ spec:
       key: {{ .Values.llm.azureOpenAI.secretRef.key | default "api-key" | quote }}
   {{- else if eq .Values.llm.provider "nirmataAI" }}
   nirmataAI:
-    endpoint: {{ .Values.llm.nirmataAI.endpoint | default "https://nirmata.io" | quote }}
+    endpoint: {{ .Values.nirmata.endpoint | default "https://nirmata.io" | quote }}
     model: {{ .Values.llm.nirmataAI.model | quote }}
     apiKeySecretRef:
       name: {{ .Values.nirmata.apiTokenSecret | default "nirmata-api-token" | quote }}

--- a/charts/go-agent-remediator/values.schema.json
+++ b/charts/go-agent-remediator/values.schema.json
@@ -47,7 +47,6 @@
           "type": "object",
           "additionalProperties": true,
           "properties": {
-            "endpoint": { "type": "string" },
             "model": { "type": "string" }
           }
         }
@@ -57,6 +56,7 @@
       "type": "object",
       "additionalProperties": true,
       "properties": {
+        "endpoint": { "type": "string" },
         "apiTokenSecret": {
           "type": "string",
           "minLength": 1

--- a/charts/go-agent-remediator/values.yaml
+++ b/charts/go-agent-remediator/values.yaml
@@ -51,10 +51,10 @@ llm:
       # Defaults to standard header key
       key: "api-key"
   nirmataAI:
-    endpoint: "https://nirmata.io"
     model: ""
 
 nirmata:
+  endpoint: "https://nirmata.io"
   # Name of secret containing Nirmata API token
   # Create manually: kubectl create secret generic nirmata-api-token --from-literal=api-token=YOUR_TOKEN -n nirmata
   apiTokenSecret: "nirmata-api-token"


### PR DESCRIPTION
This PR syncs the updated Helm chart from `nirmata/go-agent-remediator`.