### PR TITLE
Sync chart from nirmata/go-agent-remediator

### DIFF
--- a/charts/go-agent-remediator/crds/serviceagents.nirmata.io_remediators.yaml
+++ b/charts/go-agent-remediator/crds/serviceagents.nirmata.io_remediators.yaml
@@ -178,10 +178,10 @@ spec:
                   Target defines the target configuration for remediation
                   Optional when LocalCluster is true (will use current cluster)
                 properties:
-                  argoHubTarget:
+                  argoHub:
                     description: ArgoHubTarget holds cluster-based targeting configuration
                     properties:
-                      argoAppSelector:
+                      appSelector:
                         description: |-
                           ArgoAppSelector defines how to select Argo applications for remediation
                           If not specified, no applications will be selected
@@ -259,7 +259,7 @@ spec:
                           type: string
                         type: array
                     type: object
-                  localClusterTarget:
+                  localCluster:
                     description: LocalClusterTarget holds local cluster-based targeting
                       configuration
                     properties:
@@ -285,15 +285,14 @@ spec:
                     required:
                     - repoNamespaceMappingRef
                     type: object
-                  vcsTarget:
+                  vcs:
                     description: VCSTarget holds VCS-based targeting configuration
                     type: object
                 type: object
                 x-kubernetes-validations:
-                - message: exactly one of localClusterTarget or argoHubTarget must
-                    be set
-                  rule: (has(self.localClusterTarget) && !has(self.argoHubTarget))
-                    || (!has(self.localClusterTarget) && has(self.argoHubTarget))
+                - message: exactly one of localCluster or argoHub must be set
+                  rule: (has(self.localCluster) && !has(self.argoHub)) || (!has(self.localCluster)
+                    && has(self.argoHub))
             required:
             - environment
             - remediation

--- a/charts/go-agent-remediator/templates/remediator.yaml
+++ b/charts/go-agent-remediator/templates/remediator.yaml
@@ -12,26 +12,26 @@ spec:
   {{- if .Values.remediator.target }}
   target:
     {{- if eq .Values.remediator.environment.type "localCluster" }}
-    localClusterTarget:
+    localCluster:
       repoNamespaceMappingRef:
-        name: {{ .Values.remediator.target.localClusterTarget.repoNamespaceMappingRef.name | default "repo-namespace-mapping" }}
-        namespace: {{ .Values.remediator.target.localClusterTarget.repoNamespaceMappingRef.namespace | default .Release.Namespace }}
-        {{- if .Values.remediator.target.localClusterTarget.repoNamespaceMappingRef.key }}
-        key: {{ .Values.remediator.target.localClusterTarget.repoNamespaceMappingRef.key }}
+        name: {{ .Values.remediator.target.localCluster.repoNamespaceMappingRef.name | default "repo-namespace-mapping" }}
+        namespace: {{ .Values.remediator.target.localCluster.repoNamespaceMappingRef.namespace | default .Release.Namespace }}
+        {{- if .Values.remediator.target.localCluster.repoNamespaceMappingRef.key }}
+        key: {{ .Values.remediator.target.localCluster.repoNamespaceMappingRef.key }}
         {{- end }}
     {{- else if eq .Values.remediator.environment.type "argoHub" }}
-    argoHubTarget:
-      {{- if .Values.remediator.target.argoHubTarget }}
-      {{- if .Values.remediator.target.argoHubTarget.clusterNames }}
+    argoHub:
+      {{- if .Values.remediator.target.argoHub }}
+      {{- if .Values.remediator.target.argoHub.clusterNames }}
       clusterNames:
-        {{- toYaml .Values.remediator.target.argoHubTarget.clusterNames | nindent 8 }}
+        {{- toYaml .Values.remediator.target.argoHub.clusterNames | nindent 8 }}
       {{- end }}
-      {{- if .Values.remediator.target.argoHubTarget.clusterServerUrls }}
+      {{- if .Values.remediator.target.argoHub.clusterServerUrls }}
       clusterServerUrls:
-        {{- toYaml .Values.remediator.target.argoHubTarget.clusterServerUrls | nindent 8 }}
+        {{- toYaml .Values.remediator.target.argoHub.clusterServerUrls | nindent 8 }}
       {{- end }}
-      {{- with .Values.remediator.target.argoHubTarget.argoAppSelector }}
-      argoAppSelector:
+      {{- with .Values.remediator.target.argoHub.appSelector }}
+      appSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- end }}

--- a/charts/go-agent-remediator/values.yaml
+++ b/charts/go-agent-remediator/values.yaml
@@ -100,12 +100,12 @@ remediator:
   environment:
     type: argoHub  # Options: localCluster, argoHub
   target:
-    argoHubTarget:
+    argoHub:
       clusterNames: []
       clusterServerUrls: []
-      argoAppSelector:
+      appSelector:
         allApps: true
-    # localClusterTarget:
+    # localCluster:
     #   repoNamespaceMappingRef:
     #     name: repo-namespace-mapping
     #     namespace: nirmata


### PR DESCRIPTION
This PR syncs the updated Helm chart from `nirmata/go-agent-remediator`.