### PR TITLE
Sync chart from nirmata/go-kube-controller

### DIFF
--- a/charts/nirmata-kube-controller/Chart.yaml
+++ b/charts/nirmata-kube-controller/Chart.yaml
@@ -16,14 +16,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.3.16-rc3
+version: 0.3.16
 
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.10.25-rc3"
+appVersion: "v3.10.25"
 
 maintainers:
   - name: Nirmata


### PR DESCRIPTION
This PR syncs the updated Helm chart from `nirmata/go-kube-controller`.