### PR TITLE
Sync chart from nirmata/go-service-agent

### DIFF
--- a/charts/nirmata-agent/Chart.yaml
+++ b/charts/nirmata-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nirmata-agent
 description: A Helm chart for Nirmata Service Agents
 type: application
-version: v0.2.7-rc.2
-appVersion: "v0.2.7-rc.2"
+version: v0.2.7-rc.3
+appVersion: "v0.2.7-rc.3"
 keywords:
   - kubernetes
   - serviceagents


### PR DESCRIPTION
This PR syncs the updated Helm chart from `nirmata/go-service-agent`.