### PR TITLE
Sync chart from nirmata/go-kube-controller

### DIFF
--- a/charts/nirmata-kube-controller/Chart.yaml
+++ b/charts/nirmata-kube-controller/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.3.16
+version: 0.3.17-rc.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/nirmata-kube-controller/values.yaml
+++ b/charts/nirmata-kube-controller/values.yaml
@@ -42,9 +42,9 @@ global:
 # otelAgent contains configuration for the nirmata otel agent, which is used for observability and monitoring.
 otelAgent:
   # imageTag is the tag or version of the otel-agent image.
-  imageTag: "nirmata-0.130.1"
+  imageTag: "nirmata-0.151.0"
 
-  kubectlImage: "ghcr.io/nirmata/kubectl:1.33.2"
+  kubectlImage: "ghcr.io/nirmata/kubectl:nirmata-kubectl-1.35-hardened"
   # resources defines the resource requests and limits for the otel-agent
   resources:
     requests:


### PR DESCRIPTION
This PR syncs the updated Helm chart from `nirmata/go-kube-controller`.