### PR TITLE
Sync chart from nirmata/go-kube-controller

### DIFF
--- a/charts/nirmata-kube-controller/Chart.yaml
+++ b/charts/nirmata-kube-controller/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.3.17-rc.2
+version: 0.3.17-rc.3
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/nirmata-kube-controller/templates/NOTES.txt
+++ b/charts/nirmata-kube-controller/templates/NOTES.txt
@@ -1,0 +1,10 @@
+​
+Release:       {{ .Release.Name }}
+Namespace:     {{ .Release.Namespace }}
+Revision:      {{ .Release.Revision }}
+ChartVersion:  {{ .Chart.Version }}
+AppVersion:    {{ .Chart.AppVersion }}
+
+Verify the deployment:
+  kubectl -n {{ .Release.Namespace }} get pods
+  kubectl -n {{ .Release.Namespace }} rollout status deploy/nirmata-kube-controller

--- a/charts/nirmata-kube-controller/templates/nirmata-kube-controller.yaml
+++ b/charts/nirmata-kube-controller/templates/nirmata-kube-controller.yaml
@@ -704,8 +704,7 @@ spec:
       serviceAccount: nirmata
       containers:
       - name: otel-agent
-        command:
-        - /otelcol
+        args:
         - --config=/etc/otel/config.yaml
         image: "{{ .Values.global.imageRegistry }}/{{ .Values.global.imageRepository }}/otel-collector:{{ .Values.otelAgent.imageTag }}"
         resources:


### PR DESCRIPTION
This PR syncs the updated Helm chart from `nirmata/go-kube-controller`.