### PR TITLE
fix(kyverno): block install/upgrade when stale reporting CRDs are present

### DIFF
--- a/charts/kyverno/templates/hooks/pre-upgrade-stale-crd-check.yaml
+++ b/charts/kyverno/templates/hooks/pre-upgrade-stale-crd-check.yaml
@@ -1,0 +1,182 @@
+{{- if eq (include "kyverno.installReportsServer" .) "true" -}}
+{{- if not .Values.global.templating.enabled -}}
+{{- $automountSAToken := .Values.webhooksCleanup.serviceAccount.automountServiceAccountToken }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "kyverno.fullname" . }}-stale-crd-check
+  namespace: {{ template "kyverno.namespace" . }}
+  labels:
+    {{- include "kyverno.hooks.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "kyverno.fullname" . }}-stale-crd-check
+  labels:
+    {{- include "kyverno.hooks.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "kyverno.fullname" . }}-stale-crd-check
+  labels:
+    {{- include "kyverno.hooks.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kyverno.fullname" . }}-stale-crd-check
+    namespace: {{ template "kyverno.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "kyverno.fullname" . }}-stale-crd-check
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "kyverno.fullname" . }}-stale-crd-check
+  namespace: {{ template "kyverno.namespace" . }}
+  labels:
+    {{- include "kyverno.hooks.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 600
+  template:
+    {{- if or .Values.webhooksCleanup.podAnnotations .Values.webhooksCleanup.podLabels }}
+    metadata:
+      {{- with .Values.webhooksCleanup.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhooksCleanup.podLabels }}
+      labels:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+    spec:
+      serviceAccountName: {{ template "kyverno.fullname" . }}-stale-crd-check
+      automountServiceAccountToken: {{ $automountSAToken }}
+      {{- with .Values.webhooksCleanup.podSecurityContext }}
+      securityContext:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      restartPolicy: Never
+      {{- with .Values.webhooksCleanup.imagePullSecrets | default .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- tpl (include "kyverno.sortedImagePullSecrets" .) $ | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: check
+          image: {{ (include "kyverno.image" (dict "globalRegistry" .Values.global.image.registry "image" .Values.webhooksCleanup.image "defaultTag" (default .Chart.AppVersion .Values.webhooksCleanup.image.tag) "fipsEnabled" .Values.fipsEnabled)) | quote }}
+          imagePullPolicy: {{ .Values.webhooksCleanup.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              CRDS="policyreports.wgpolicyk8s.io clusterpolicyreports.wgpolicyk8s.io ephemeralreports.reports.kyverno.io clusterephemeralreports.reports.kyverno.io"
+              STALE=""
+              for c in $CRDS; do
+                if kubectl get crd "$c" -o name >/dev/null 2>&1; then
+                  STALE="$STALE $c"
+                fi
+              done
+              if [ -n "$STALE" ]; then
+                echo
+                echo "  +--------------------------------------------------------------------------------------------------------------------------------------+"
+                echo "  | reports-server is being installed but legacy reporting CRDs already exist on the cluster.                                            |"
+                echo "  | reports-server registers aggregated APIServices for reports.kyverno.io and wgpolicyk8s.io and owns those resources at runtime.       |"
+                echo "  | Pre-existing native CRDs collide with those APIServices and trigger a duplicate-path error in the Kubernetes OpenAPI spec (1.28+).   |"
+                echo "  | The CRDs listed below must be deleted before the upgrade can proceed - reports-server will serve these resources via APIServices.    |"
+                echo "  +--------------------------------------------------------------------------------------------------------------------------------------+"
+                echo
+                echo "  Stale CRDs detected:"
+                for c in $STALE; do echo "    - $c"; done
+                echo
+                echo "  Run the following and re-run the upgrade:"
+                echo "    kubectl delete crd$STALE"
+                echo
+                exit 1
+              fi
+              echo "No stale reporting CRDs found. Proceeding with install/upgrade."
+          {{- with .Values.webhooksCleanup.resources }}
+          resources:
+            {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with .Values.webhooksCleanup.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if not $automountSAToken }}
+          volumeMounts:
+            - name: serviceaccount-token
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              readOnly: true
+          {{- end }}
+      {{- with .Values.webhooksCleanup.tolerations | default .Values.global.tolerations}}
+      tolerations:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhooksCleanup.nodeSelector | default .Values.global.nodeSelector }}
+      nodeSelector:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.webhooksCleanup.podAntiAffinity .Values.webhooksCleanup.podAffinity .Values.webhooksCleanup.nodeAffinity }}
+      affinity:
+        {{- with .Values.webhooksCleanup.podAntiAffinity }}
+        podAntiAffinity:
+          {{- tpl (toYaml .) $ | nindent 10 }}
+        {{- end }}
+        {{- with .Values.webhooksCleanup.podAffinity }}
+        podAffinity:
+          {{- tpl (toYaml .) $ | nindent 10 }}
+        {{- end }}
+        {{- with .Values.webhooksCleanup.nodeAffinity }}
+        nodeAffinity:
+          {{- tpl (toYaml .) $ | nindent 10 }}
+        {{- end }}
+      {{- end }}
+      {{- if not $automountSAToken }}
+      volumes:
+        - name: serviceaccount-token
+          projected:
+            defaultMode: 0444
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+              - downwardAPI:
+                  items:
+                    - path: namespace
+                      fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+      {{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/kyverno/templates/validate.yaml
+++ b/charts/kyverno/templates/validate.yaml
@@ -51,6 +51,36 @@
   -}}
 {{- end -}}
 
+{{- if eq (include "kyverno.installReportsServer" .) "true" -}}
+  {{- $staleCRDs := list -}}
+  {{- range $crdName := list "policyreports.wgpolicyk8s.io" "clusterpolicyreports.wgpolicyk8s.io" "ephemeralreports.reports.kyverno.io" "clusterephemeralreports.reports.kyverno.io" -}}
+    {{- if lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" $crdName -}}
+      {{- $staleCRDs = append $staleCRDs $crdName -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if $staleCRDs -}}
+    {{- $msg := list
+      ""
+      ""
+      "  +--------------------------------------------------------------------------------------------------------------------------------------+"
+      "  | reports-server is being installed but legacy reporting CRDs already exist on the cluster.                                            |"
+      "  | reports-server registers aggregated APIServices for reports.kyverno.io and wgpolicyk8s.io and owns those resources at runtime.       |"
+      "  | Pre-existing native CRDs collide with those APIServices and trigger a duplicate-path error in the Kubernetes OpenAPI spec (1.28+).   |"
+      "  | The CRDs listed below must be deleted before the upgrade can proceed — reports-server will serve these resources via APIServices.    |"
+      "  +--------------------------------------------------------------------------------------------------------------------------------------+"
+      ""
+      "  Stale CRDs detected:"
+    -}}
+    {{- range $name := $staleCRDs -}}
+      {{- $msg = append $msg (printf "    - %s" $name) -}}
+    {{- end -}}
+    {{- $msg = append $msg "" -}}
+    {{- $msg = append $msg (printf "  Run the following and re-run the upgrade:\n    kubectl delete crd %s" (join " " $staleCRDs)) -}}
+    {{- $msg = append $msg "" -}}
+    {{- fail (join "\n" $msg) -}}
+  {{- end -}}
+{{- end -}}
+
 {{- if and (eq .Values.crds.reportsServer.enabled true) (eq (include "kyverno.installReportsServer" .) "false") -}}
   {{- $reportsServerPods := lookup "v1" "Pod" (include "kyverno.namespace" .) "" -}}
   {{- $apiServices := lookup "apiregistration.k8s.io/v1" "APIService" "" "" -}}


### PR DESCRIPTION
## Summary

Adds a stale-CRD safety net that prevents `reports-server` from being installed or upgraded onto a cluster that still has the legacy reporting CRDs. Two complementary checks are introduced — one for direct `helm` users (fast template-time fail) and one for ArgoCD users (in-cluster Job hook). Both surface the same actionable boxed error.

This is a follow-up to #1065 which addressed the values-side mismatch (`reports-server.install=true` + `crds.reportsServer.enabled=false`). #1065 does not detect the cluster-state case where a release was previously installed with the native reporting CRDs and is now being upgraded with `reports-server.install=true` — that path is what this PR closes.

## Background

When `reports-server` is enabled it registers aggregated APIServices for `reports.kyverno.io` and `wgpolicyk8s.io` and owns those resources at runtime. If the native CRDs for those groups still exist on the cluster from an earlier install, they collide with the APIService registrations and trigger a duplicate-path error in the Kubernetes OpenAPI spec on K8s 1.28+:

> spec.paths[\"/apis/wgpolicyk8s.io/v1alpha2\"]: Duplicate value: \"…\"

The four CRDs that conflict:

- `policyreports.wgpolicyk8s.io`
- `clusterpolicyreports.wgpolicyk8s.io`
- `ephemeralreports.reports.kyverno.io`
- `clusterephemeralreports.reports.kyverno.io`

When `reports-server` is enabled, the chart's CRDs sub-chart already suppresses these (see `(not .Values.reportsServer.enabled)` gate in `charts/kyverno/charts/crds/templates/...`). But Helm's CRD-on-upgrade behavior plus user-side `kubectl apply` history means they often persist on the cluster even when the chart wouldn't render them. The user has no signal about it until reports-server fails to start.

## Why two checks (and not just one)

Helm `lookup` requires a live cluster connection. It returns `nil` under `helm template` — and **ArgoCD's repo-server runs `helm template`** with no kubeconfig. So a `lookup`-based block in `validate.yaml` is invisible to ArgoCD users. Conversely, a Job-only approach makes direct `helm` users wait for a Pod spinup just to learn their values are wrong.

| Path | `validate.yaml` lookup | Hook Job |
|---|---|---|
| `helm install` / `helm upgrade` | ✅ aborts at template time | (never reached) |
| `helm template` (rendering only) | ❌ skipped (lookup returns nil — by design) | (rendered but not run) |
| ArgoCD sync | ❌ skipped (helm template path) | ✅ runs as PreSync, fails sync |
| Skaffold / Argo Rollouts manifest pipelines | depends on rendering mode | ✅ runs at apply time |

Both paths emit the **same** boxed error message listing the offending CRDs and the exact `kubectl delete crd …` command to run before retrying.

## Changes

### 1. `charts/kyverno/templates/validate.yaml` (+30 lines)

New `lookup`-based block, placed alongside the existing `installReportsServer=true` validation. Only fires when `installReportsServer` is true; iterates the four reporting CRDs; if any are present, fails the template with the boxed message.

### 2. `charts/kyverno/templates/hooks/pre-upgrade-stale-crd-check.yaml` (+182 lines, new file)

Pre-install / pre-upgrade hook that creates:

- `ServiceAccount` (dedicated, weight `-10`)
- `ClusterRole` with minimum privilege: `get,list customresourcedefinitions` only
- `ClusterRoleBinding`
- `Job` (weight `-5`, `backoffLimit: 0`, `ttlSecondsAfterFinished: 600`) that runs `kubectl get crd` against each of the four CRDs and exits 1 with the boxed message if any are found

`helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded` — failed pods are kept so users (and `kubectl logs`) can inspect the message. Successful pods + RBAC are cleaned up automatically.

## Operational parity with existing hooks

The Job mirrors `pre-delete-scale-to-zero.yaml` exactly so cluster operators get the same knobs they already use for the other kubectl-based hooks. Every container/pod attribute is sourced from `.Values.webhooksCleanup.*`:

| Field | Sourced from |
|---|---|
| Container image + pullPolicy | `webhooksCleanup.image` (via `kyverno.image` helper) |
| `imagePullSecrets` | `webhooksCleanup.imagePullSecrets` ⇒ `global.imagePullSecrets` |
| Pod-level `securityContext` | `webhooksCleanup.podSecurityContext` |
| Container `securityContext` | `webhooksCleanup.securityContext` (defaults: `runAsNonRoot`, `runAsUser:65534`, `readOnlyRootFilesystem`, drop ALL caps, seccomp `RuntimeDefault`) |
| `resources` | `webhooksCleanup.resources` (defaults: 100m/256Mi limits, 10m/64Mi requests) |
| `automountServiceAccountToken` (+ projected fallback volume) | `webhooksCleanup.serviceAccount.automountServiceAccountToken` |
| Pod `labels` / `annotations` | `webhooksCleanup.podLabels` / `podAnnotations` |
| `tolerations` | `webhooksCleanup.tolerations` ⇒ `global.tolerations` |
| `nodeSelector` | `webhooksCleanup.nodeSelector` ⇒ `global.nodeSelector` |
| `affinity` (pod / antiPod / node) | `webhooksCleanup.podAffinity` / `podAntiAffinity` / `nodeAffinity` |

No new values keys introduced.

## What the user sees on failure

\`\`\`
+--------------------------------------------------------------------------------------------------------------------------------------+
| reports-server is being installed but legacy reporting CRDs already exist on the cluster.                                            |
| reports-server registers aggregated APIServices for reports.kyverno.io and wgpolicyk8s.io and owns those resources at runtime.       |
| Pre-existing native CRDs collide with those APIServices and trigger a duplicate-path error in the Kubernetes OpenAPI spec (1.28+).   |
| The CRDs listed below must be deleted before the upgrade can proceed - reports-server will serve these resources via APIServices.    |
+--------------------------------------------------------------------------------------------------------------------------------------+

  Stale CRDs detected:
    - policyreports.wgpolicyk8s.io
    - clusterpolicyreports.wgpolicyk8s.io
    - ephemeralreports.reports.kyverno.io
    - clusterephemeralreports.reports.kyverno.io

  Run the following and re-run the upgrade:
    kubectl delete crd policyreports.wgpolicyk8s.io clusterpolicyreports.wgpolicyk8s.io ephemeralreports.reports.kyverno.io clusterephemeralreports.reports.kyverno.io
\`\`\`

On a clean cluster:

\`\`\`
No stale reporting CRDs found. Proceeding with install/upgrade.
\`\`\`

## Test plan

End-to-end tested against a kind cluster (K8s 1.35) with ArgoCD installed, using a downstream branch that imported `charts/kyverno` from this PR.

- [x] `helm lint charts/kyverno --set reports-server.install=true --set crds.reportsServer.enabled=true` — clean
- [x] `helm template` with `reports-server.install=false` — hook does not render (gate is correct)
- [x] `helm template` with `reports-server.install=true` — renders 4 resources (SA, ClusterRole, ClusterRoleBinding, Job) with correct hook annotations + the chart's standard kubectl image (`reg.nirmata.io/nirmata/kubectl:nirmata-kubectl-1.35-hardened`)
- [x] ArgoCD sync with all four stale CRDs seeded — PreSync Job exits 1, ArgoCD app stays `OutOfSync`/`Failed`, boxed message visible in Job log
- [x] After `kubectl delete crd …`, ArgoCD retries — Job exits 0 with \"No stale reporting CRDs found\", post-Sync proceeds, app reaches `Healthy`/`Succeeded`
- [x] Rendered Job pod attributes verified to match `webhooksCleanup` values: image, resources `{cpu:100m,memory:256Mi}` / `{cpu:10m,memory:64Mi}`, securityContext `{runAsUser:65534, runAsNonRoot:true, readOnlyRootFilesystem:true, capabilities.drop:[ALL], seccompProfile.type:RuntimeDefault}`

## Migration / upgrade notes

For existing customers upgrading from a release that had `reports-server.install=false` (native CRDs installed) to a release with `reports-server.install=true`:

1. The first upgrade attempt will fail at the new check (whether via helm or ArgoCD).
2. Operator runs `kubectl delete crd policyreports.wgpolicyk8s.io clusterpolicyreports.wgpolicyk8s.io ephemeralreports.reports.kyverno.io clusterephemeralreports.reports.kyverno.io` (the exact command is in the error output).
3. Re-run the upgrade — hook passes, install proceeds, reports-server's APIServices take over for these resource groups.

Note that step 2 deletes any `PolicyReport`/`ClusterPolicyReport`/`EphemeralReport`/`ClusterEphemeralReport` instances on the cluster. That is the expected behavior — once `reports-server` takes over, it generates fresh reports from the policy state. Any pre-existing report data is transient by design.

## Files changed

- `charts/kyverno/templates/validate.yaml` — new `lookup`-based stale-CRD block (+30)
- `charts/kyverno/templates/hooks/pre-upgrade-stale-crd-check.yaml` — new hook file (+182)

Related: #1065