### PR TITLE
Sync chart from nirmata/go-kube-controller

### DIFF
--- a/charts/nirmata-kube-controller/Chart.yaml
+++ b/charts/nirmata-kube-controller/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.3.17-rc.3
+version: 0.3.17
 
 
 # This is the version number of the application being deployed. This version number should be


### PR DESCRIPTION
This PR syncs the updated Helm chart from `nirmata/go-kube-controller`.