### PR TITLE
Sync chart from nirmata/reports-server

### DIFF
--- a/charts/reports-server/templates/cluster-roles.yaml
+++ b/charts/reports-server/templates/cluster-roles.yaml
@@ -71,6 +71,12 @@ rules:
     - watch
     - deletecollection
 - apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+  verbs:
+    - list
+- apiGroups:
     - ''
     - events.k8s.io
   resources:


### PR DESCRIPTION
This PR syncs the updated Helm chart from `nirmata/reports-server`.