### PR TITLE
Sync chart from nirmata/reports-server

### DIFF
--- a/charts/reports-server/Chart.yaml
+++ b/charts/reports-server/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: reports-server
 type: application
-version: 0.2.29
-appVersion: v0.2.25
+version: 0.2.30-rc1
+appVersion: v0.2.26-rc1
 home: https://nirmata.com/
 annotations:
   artifacthub.io/links: |

--- a/charts/reports-server/templates/cluster-roles.yaml
+++ b/charts/reports-server/templates/cluster-roles.yaml
@@ -71,6 +71,12 @@ rules:
     - watch
     - deletecollection
 - apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+  verbs:
+    - list
+- apiGroups:
     - ''
     - events.k8s.io
   resources:


### PR DESCRIPTION
This PR syncs the updated Helm chart from `nirmata/reports-server`.