### PR TITLE
Sync chart from nirmata/reports-server

### DIFF
--- a/charts/reports-server/Chart.yaml
+++ b/charts/reports-server/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: reports-server
 type: application
-version: 0.2.30-rc1
-appVersion: v0.2.26-rc1
+version: 0.2.30-rc2
+appVersion: v0.2.26
 home: https://nirmata.com/
 annotations:
   artifacthub.io/links: |

--- a/charts/reports-server/templates/cluster-roles.yaml
+++ b/charts/reports-server/templates/cluster-roles.yaml
@@ -41,12 +41,12 @@ rules:
     - apiservices
   verbs:
     - create
+    - get
 - apiGroups:
     - apiregistration.k8s.io
   resources:
     - apiservices
   verbs:
-    - get
     - delete
     - update
     - patch
@@ -54,6 +54,8 @@ rules:
     - v1.reports.kyverno.io
     - v1alpha2.wgpolicyk8s.io
     - v1alpha1.openreports.io
+    - v1beta1.wgpolicyk8s.io
+    - v1alpha1.wgpolicyk8s.io
 - apiGroups:
     - wgpolicyk8s.io
   resources:


### PR DESCRIPTION
This PR syncs the updated Helm chart from `nirmata/reports-server`.