### PR TITLE
Sync chart from nirmata/reports-server

### DIFF
--- a/charts/reports-server/Chart.yaml
+++ b/charts/reports-server/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: reports-server
 type: application
-version: 0.2.30-rc2
-appVersion: v0.2.26
+version: 0.2.30
+appVersion: v0.2.27
 home: https://nirmata.com/
 annotations:
   artifacthub.io/links: |

--- a/charts/reports-server/templates/etcd.yaml
+++ b/charts/reports-server/templates/etcd.yaml
@@ -1,6 +1,15 @@
 {{- if .Values.config.etcd.enabled }}
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "reports-server.fullname" . }}-etcd
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: etcd-reports-server
+    {{- include "reports-server.labels" . | nindent 4 }}
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: etcd
@@ -55,6 +64,8 @@ spec:
 {{- if .Values.config.etcd.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.config.etcd.imagePullSecrets | nindent 8 }}
 {{- end }}
+      serviceAccountName: {{ include "reports-server.fullname" . }}-etcd
+      automountServiceAccountToken: false
 {{- if .Values.config.etcd.podSecurityContext }}
       securityContext: {{ toYaml .Values.config.etcd.podSecurityContext | nindent 8 }}
 {{- end }}

--- a/charts/reports-server/values.yaml
+++ b/charts/reports-server/values.yaml
@@ -233,7 +233,7 @@ config:
       # -- Image repository
       repository: nirmata/etcd
       # -- Image tag
-      tag: 3.6.9-hardened
+      tag: 3.6.12-hardened
 
     # -- Image pull secrets
     imagePullSecrets: []
@@ -279,11 +279,14 @@ config:
 
     # -- Pod-level security context for etcd pods
     # Applies to all containers in the pod (e.g. fsGroup, runAsUser, sysctls)
-    podSecurityContext: {}
+    podSecurityContext:
+      runAsNonRoot: true
+      fsGroup: 65532
 
     # -- Container-level security context for the etcd container
     # @default -- See [values.yaml](values.yaml)
-    securityContext: {}
+    securityContext:
+      allowPrivilegeEscalation: false
 
   db:
 


### PR DESCRIPTION
This PR syncs the updated Helm chart from `nirmata/reports-server`.