### PR TITLE
fix(cluster-registrator): honor .Values.namespace and stop dropping the last item in the pre-delete hook

### DIFF
--- a/charts/cluster-registrator/Chart.yaml
+++ b/charts/cluster-registrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.19
+version: 0.1.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cluster-registrator/templates/job.yaml
+++ b/charts/cluster-registrator/templates/job.yaml
@@ -394,7 +394,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: nirmata:cluster-registrator-ns-admin
-  namespace: nirmata
+  namespace: {{ .Values.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/cluster-registrator/templates/pre-delete-hook.yaml
+++ b/charts/cluster-registrator/templates/pre-delete-hook.yaml
@@ -26,16 +26,16 @@ spec:
           #!/bin/bash
           set -e
           # Fetch the ConfigMap and extract items data
-          items=`kubectl get configmap items-created -n nirmata -o custom-columns=DATA:.data --no-headers | sed 's/map\[//;s/\]//;s/ /\n/g' | sed 's/[:=]/ /')`
+          items=`kubectl get configmap items-created -n {{ .Values.namespace }} --ignore-not-found -o custom-columns=DATA:.data --no-headers | sed 's/map\[//;s/\]//;s/ /\n/g' | sed 's/[:=]/ /'`
           # Iterate through the items and delete them
-          echo -n "$items" | while read -r line; do
+          echo "$items" | while read -r line; do
+            [ -n "$line" ] || continue
             kind=$(echo $line | awk '{print $1}')
             names=$(echo $line | awk '{print $2}' | sed -e 's/,/ /g')
             for name in `echo $names`; do
-              echo "5"
-              kubectl delete $kind $name -n nirmata || true
+              kubectl delete $kind $name -n {{ .Values.namespace }} || true
             done
           done
           
           # Delete the ConfigMap itself
-          kubectl delete configmap items-created -n nirmata || true
+          kubectl delete configmap items-created -n {{ .Values.namespace }} || true


### PR DESCRIPTION
This PR proposes a fix for two defects in the `cluster-registrator` chart: its pre-delete cleanup hook never processes the last entry of the `items-created` ConfigMap, so one recorded resource always survives `helm uninstall`, and `.Values.namespace` is ignored by both that hook and the `nirmata:cluster-registrator-ns-admin` RoleBinding. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/288. You can sign in with your GitHub ID to claim ownership of the project.

## The defects

**1. The pre-delete hook silently skips the last recorded item.** The hook reads `items-created` into `$items`, then iterates with `echo -n "$items" | while read -r line`. `echo -n` leaves the final line without a trailing newline, and `read` returns non-zero on an unterminated final line, so the loop body never runs for it — whichever key sorts last in the ConfigMap is never deleted and outlives the release.

Reproduced on `main` @ `8a98a27`, by running the hook's own rendered script inside the image the chart pins (`ghcr.io/nirmata/kubectl:1.30.2`, where `sh` is busybox), against a stand-in `kubectl` that reports three created resources — two ClusterRoles and one ClusterRoleBinding:

```console
$ cat stub/kubectl
#!/usr/bin/sh
echo "  kubectl $*" >&2
[ "$1" = "get" ] && [ "$2" = "configmap" ] && echo 'map[ClusterRole:nirmata:cluster-registrator,nirmata:cluster-registrator-nirmata-readonly ClusterRoleBinding:nirmata:cluster-registrator]'
exit 0

$ helm template cr charts/cluster-registrator --show-only templates/pre-delete-hook.yaml \
    | python3 -c 'import sys,yaml;print(yaml.safe_load(sys.stdin)["spec"]["template"]["spec"]["containers"][0]["args"][0])' \
    > hook.sh

$ docker run --rm -v "$PWD:/w" --entrypoint /usr/bin/sh ghcr.io/nirmata/kubectl:1.30.2 \
    -c 'PATH=/w/stub:$PATH; /usr/bin/sh /w/hook.sh'
  kubectl get configmap items-created -n nirmata -o custom-columns=DATA:.data --no-headers
5
5
  kubectl delete ClusterRole nirmata:cluster-registrator -n nirmata
  kubectl delete ClusterRole nirmata:cluster-registrator-nirmata-readonly -n nirmata
  kubectl delete configmap items-created -n nirmata
```

The ClusterRoleBinding recorded in the ConfigMap is never deleted, so it is left behind cluster-wide after the release is gone. The two stray `5` lines are a leftover `echo "5"` in the loop, dropped here as well. With this PR the same command deletes all three:

```console
  kubectl get configmap items-created -n nirmata --ignore-not-found -o custom-columns=DATA:.data --no-headers
  kubectl delete ClusterRole nirmata:cluster-registrator -n nirmata
  kubectl delete ClusterRole nirmata:cluster-registrator-nirmata-readonly -n nirmata
  kubectl delete ClusterRoleBinding nirmata:cluster-registrator -n nirmata
  kubectl delete configmap items-created -n nirmata
```

**2. `.Values.namespace` is ignored in two places.** `RoleBinding/nirmata:cluster-registrator-ns-admin` hardcodes `metadata.namespace: nirmata`, and every `kubectl` call in the pre-delete hook hardcodes `-n nirmata`:

```console
$ helm template cr charts/cluster-registrator --set namespace=n4k-system | grep -nE 'namespace: nirmata|-n nirmata'
220:  namespace: nirmata
314:          items=`kubectl get configmap items-created -n nirmata -o custom-columns=DATA:.data --no-headers | sed 's/map\[//;s/\]//;s/ /\n/g' | sed 's/[:=]/ /')`
321:              kubectl delete $kind $name -n nirmata || true
326:          kubectl delete configmap items-created -n nirmata || true
```

A release installed anywhere else therefore binds `admin` into a namespace the chart has not created — the install fails when that namespace does not already exist — and its cleanup hook then runs against `nirmata` instead of the namespace it was installed in. After this PR the same command matches nothing.

## The change

- `templates/pre-delete-hook.yaml`: `echo -n "$items"` becomes `echo "$items"` with an empty-line guard, so every recorded entry is processed; the hardcoded `-n nirmata` on all three `kubectl` calls is templated from `.Values.namespace`; `--ignore-not-found` is added to the `get` so uninstalling a release that never registered does not surface a `NotFound` message; and a stray `)` inside the backtick substitution is removed — busybox `sh` tolerates it, `bash` and `zsh` reject it outright, and `hooks.image.*` lets the hook be pointed at a different `kubectl` image.
- `templates/job.yaml`: the ns-admin RoleBinding's `metadata.namespace` now comes from `.Values.namespace`.
- `Chart.yaml`: `0.1.19` to `0.1.20`, since `ct.yaml` sets `check-version-increment: true`.

Scope: no RBAC rule, verb, or subject is changed — only the namespace the existing RoleBinding is created in. Default values render exactly as they do today apart from the `helm.sh/chart` label, so existing installs are unaffected.

## Verification

- `ct lint --remote upstream --target-branch main` — the check `.github/actions/chart-lint` runs — passes on this branch: `Old chart version: 0.1.19` / `New chart version: 0.1.20` / `Chart version ok`, then `1 chart(s) linted, 0 chart(s) failed`.
- `helm lint` and `helm template` across all ten charts with helm `v3.13.0` (the version the action pins), before and after the change: identical results, nothing newly failing.
- Rendered-manifest diff across all ten charts, at default values and with `--set namespace=n4k-system`: only `cluster-registrator` changes, and at default values that diff is just the four script lines plus the chart version label. (`kube-bench-adapter` also differs between any two renders of the same tree — that is a randomly generated name inside the chart itself, unrelated to this change.)
- The hook script was executed inside `ghcr.io/nirmata/kubectl:1.30.2` for three scenarios — default namespace, `--set namespace=n4k-system`, and a missing `items-created` ConfigMap — both before and after.

## How this was managed

We tracked this work on a board imported from this repository's own issues and pull requests (1,162 stories): the story for this change is at https://eastagiletracker.com/projects/288/stories/184159, on the board at https://eastagiletracker.com/projects/288.

![board](https://raw.githubusercontent.com/eastagiletracker/kyverno-charts/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
