### PR TITLE
feat: publish and sign Helm charts to GHCR as OCI artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: lint
+    permissions:
+      contents: write   # chart-releaser pushes gh-pages + creates GitHub Releases
+      packages: write   # helm push to ghcr.io
+      id-token: write   # keyless cosign (OIDC)
+    env:
+      # Charts published to the OCI registry. Add deliberately: everything
+      # listed here becomes publicly pullable from ghcr.io/nirmata/charts.
+      OCI_CHARTS: kyverno,reports-server
+      OCI_REGISTRY: oci://ghcr.io/${{ github.repository_owner }}/charts
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,6 +57,62 @@ jobs:
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Install Cosign
+        if: steps.releaser.outputs.changed_charts != ''
+        uses: sigstore/cosign-installer@v3.7.0
+
+      - name: Login to GitHub Container Registry
+        if: steps.releaser.outputs.changed_charts != ''
+        run: |
+          helm registry login ghcr.io \
+            --username "${GITHUB_ACTOR}" \
+            --password "${{ secrets.GITHUB_TOKEN }}"
+          cosign login ghcr.io \
+            --username "${GITHUB_ACTOR}" \
+            --password "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Publish and sign OCI charts
+        if: steps.releaser.outputs.changed_charts != ''
+        run: |
+          set -euo pipefail
+
+          # chart-releaser leaves ONLY the charts it just released here.
+          shopt -s nullglob
+          pkgs=(.cr-release-packages/*.tgz)
+          if [ ${#pkgs[@]} -eq 0 ]; then
+            echo "No packaged charts found; nothing to publish."
+            exit 0
+          fi
+
+          for pkg in "${pkgs[@]}"; do
+            name=$(helm show chart "$pkg" | awk '/^name:/{print $2}')
+            ver=$(helm show chart "$pkg" | awk '/^version:/{print $2}')
+            repo="ghcr.io/${{ github.repository_owner }}/charts/${name}"
+
+            # Allowlist gate
+            case ",${OCI_CHARTS}," in
+              *",${name},"*) ;;
+              *) echo "skip ${name}: not in OCI_CHARTS"; continue ;;
+            esac
+
+            # Idempotency: never re-push an existing tag (safe workflow re-runs)
+            if helm show chart "oci://${repo}" --version "$ver" >/dev/null 2>&1; then
+              echo "skip ${name}:${ver}: already published"
+              continue
+            fi
+
+            echo "Publishing ${name}:${ver}"
+            helm push "$pkg" "${OCI_REGISTRY}" 2>&1 | tee .digest
+            digest=$(awk -F "[, ]+" '/Digest/{print $NF}' .digest)
+
+            cosign sign --yes \
+              -a "repo=${{ github.repository }}" \
+              -a "workflow=${{ github.workflow }}" \
+              -a "ref=${{ github.sha }}" \
+              -a "kind=helm-chart" \
+              "${repo}@${digest}"
+          done
 
   notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

Charts are released only to the gh-pages Helm repo. The release job runs `helm/chart-releaser-action` and stops — and chart-releaser has **no OCI support** (its only registry code is for pulling chart *dependencies*).

Consequences today:

- `ghcr.io/nirmata/charts/kyverno` is stuck at **3.0.5** while releases are at **3.8.0-rc.4**. Anyone running `helm pull oci://ghcr.io/nirmata/charts/kyverno` silently gets a chart many releases old.
- **No charts are signed.** Upstream Kyverno has 135 `.sig` tags on its chart repo; we have none — even though our container images are signed.

## Change

Adds a publish step after chart-releaser. It pushes the tarballs chart-releaser **already produced** in `.cr-release-packages/` (which contains only the charts released on this run) and signs each with cosign.

This mirrors the pattern already in use in `enterprise-kyverno/.github/workflows/release.yaml`, which pushes install manifests to GHCR and cosign-signs them — same tooling, just never applied to charts.

Details:

- Gated on `steps.releaser.outputs.changed_charts != ''`, so no-op commits skip all three steps.
- `OCI_CHARTS` allowlist starts at `kyverno,reports-server`. Everything listed becomes **publicly pullable**, so commercial charts (`nirmata-agent`, `cloud-controller`, `cluster-registrator`, `nirmata-kube-controller`, `enterprise-kyverno-operator`) are intentionally excluded. Expand deliberately.
- Skips any tag already present in the registry, so workflow re-runs are safe.
- Adds `packages: write` (helm push) and `id-token: write` (keyless cosign) to the job. `contents: write` is stated explicitly since adding a `permissions:` block overrides the defaults chart-releaser relies on.
- Signatures are **co-located with the chart** (no `COSIGN_REPOSITORY`), so `cosign verify ghcr.io/nirmata/charts/kyverno:<ver>` works with no extra env on the consumer side. Upstream and our manifests pipeline route to a separate `ghcr.io/nirmata/signatures`, which currently denies anonymous reads — that would leave customers unable to verify. Happy to switch if org consistency is preferred.

## Before merging

- [ ] Confirm `GITHUB_TOKEN` has org-level package-write for `nirmata`.
- [ ] After the first successful run, set the new `ghcr.io/nirmata/charts/*` packages to **Public** in GHCR — new packages default to private.
- [ ] Decide what to do with the stale `charts/kyverno:3.0.5` tag (backfill or delete).

## Testing

Not exercised in CI yet — the publish path only runs on a real chart change. Suggest merging to a `release-*` branch first, or a `workflow_dispatch` dry run with the allowlist narrowed to one chart.

Chart artifacts produced by `helm push` were verified spec-correct against the existing `3.0.5`: correct Helm media types (`vnd.cncf.helm.config.v1+json` / `chart.content.v1.tar+gzip`), registry serves `application/vnd.oci.image.manifest.v1+json`, and the layer digest matches the `.tgz` byte for byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)